### PR TITLE
Add automatic bounds checking

### DIFF
--- a/studio/include/studio/settings.hpp
+++ b/studio/include/studio/settings.hpp
@@ -23,13 +23,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <QVector3D>
 #include <QWidget>
 #include <QDoubleSpinBox>
+#include <QCheckBox>
 
 struct Settings
 {
     /*
      *  Useful constructor
      */
-    Settings(QVector3D min, QVector3D max, float res, float quality);
+    Settings(QVector3D min, QVector3D max, float res, float quality,
+             bool autobounds);
 
     /*
      *  Default constructor (produces an object that shouldn't be used)
@@ -37,14 +39,31 @@ struct Settings
     Settings() : res(-1), quality(-1) { /* Nothing to do here */ }
 
     /*
+     *  Constructor for sensible settings, used by default in viewport
+     */
+    static Settings defaultSettings();
+
+    /*
      *  Estimates a reasonable resolution scale for incremental rendering
      */
     int defaultDiv() const;
+
+    /*
+     *  Converts to a string using settings_fmt
+     */
+    QString toString() const;
+
+    /*
+     *  Converts from a string to a Settings object using settings_regex
+     *  Returns default Settings and sets *okay to false on failure
+     */
+    static Settings fromString(QString s, bool* okay=nullptr);
 
     QVector3D min;
     QVector3D max;
     float res;
     float quality;
+    bool autobounds;
 
     // Used to read and write to scripts
     static QRegularExpression settings_regex;
@@ -52,7 +71,6 @@ struct Settings
 
     bool operator==(const Settings& other) const;
     bool operator!=(const Settings& other) const;
-
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -71,6 +89,8 @@ signals:
     void enable();
 
 protected:
+    Settings settings() const;
+
     QDoubleSpinBox* xmin;
     QDoubleSpinBox* xmax;
     QDoubleSpinBox* ymin;
@@ -79,4 +99,5 @@ protected:
     QDoubleSpinBox* zmax;
     QDoubleSpinBox* res;
     QDoubleSpinBox* quality;
+    QCheckBox* autobounds;
 };

--- a/studio/include/studio/shape.hpp
+++ b/studio/include/studio/shape.hpp
@@ -108,6 +108,11 @@ public:
     { return vars; }
 
     /*
+     *  Looks up the shape's bounds
+     */
+    const Kernel::Region<3>& getBounds() const { return bounds; }
+
+    /*
      *  Sets grabbed and redraws as necessary
      */
     void setGrabbed(bool g);
@@ -142,9 +147,10 @@ protected:
     bool grabbed=false;
     bool hover=false;
 
-    Kernel::Mesh* renderMesh(QPair<Settings, int> s);
-    QFuture<Kernel::Mesh*> mesh_future;
-    QFutureWatcher<Kernel::Mesh*> mesh_watcher;
+    typedef QPair<Kernel::Mesh*, Kernel::Region<3>> BoundedMesh;
+    BoundedMesh renderMesh(QPair<Settings, int> s);
+    QFuture<BoundedMesh> mesh_future;
+    QFutureWatcher<BoundedMesh> mesh_watcher;
     std::atomic_bool cancel;
 
     Kernel::Tree tree;
@@ -153,6 +159,7 @@ protected:
                 Eigen::aligned_allocator<Kernel::XTreeEvaluator>> es;
 
     QScopedPointer<Kernel::Mesh> mesh;
+    Kernel::Region<3> bounds;
     QPair<Settings, int> next;
 
     /*  running marks not just whether the future has finished, but whether

--- a/studio/src/editor.cpp
+++ b/studio/src/editor.cpp
@@ -197,17 +197,11 @@ void Editor::setKeywords(QString kws)
 
 void Editor::onSettingsChanged(Settings s)
 {
-    auto txt = script_doc->toPlainText();
-
-    auto render_str = s.settings_fmt
-        .arg(s.min.x()).arg(s.min.y()).arg(s.min.z())
-        .arg(s.max.x()).arg(s.max.y()).arg(s.max.z())
-        .arg(s.res).arg(s.quality);
+    const auto render_str = s.toString();
 
     QTextCursor c(script_doc);
-
     c.beginEditBlock();
-    auto match = s.settings_regex.match(txt);
+    auto match = s.settings_regex.match(script_doc->toPlainText());
     if (!match.hasMatch())
     {
         c.insertText(render_str);
@@ -228,22 +222,11 @@ void Editor::onScriptChanged()
     auto txt = script_doc->toPlainText();
     emit(scriptChanged(txt));
 
-    auto match = Settings::settings_regex.match(txt);
-    if (match.hasMatch())
+    bool okay = true;
+    const auto s = Settings::fromString(txt, &okay);
+    if (okay)
     {
-        bool ok = true;
-        std::vector<float> out;
-        for (int i=1; i <= match.lastCapturedIndex() && ok; ++i)
-        {
-            out.push_back(match.captured(i).toFloat(&ok));
-        }
-        if (ok)
-        {
-            Settings s({out[0], out[1], out[2]},
-                       {out[3], out[4], out[5]}, out[6], out[7]);
-
-            emit(settingsChanged(s, first_change));
-        }
+        emit(settingsChanged(s, first_change));
     }
     first_change = false;
 }

--- a/studio/src/settings.cpp
+++ b/studio/src/settings.cpp
@@ -127,17 +127,20 @@ SettingsPane::SettingsPane(Settings s)
     layout->addWidget(zmin, 3, 1);
     layout->addWidget(zmax, 3, 2);
 
+    layout->addWidget(new QLabel("Auto-bounding:"), 4, 0, 1, 2);
+    layout->addWidget(autobounds, 4, 2);
+
     QFrame* line;
     line = new QFrame();
     line->setFrameShape(QFrame::HLine);
     line->setFrameShadow(QFrame::Raised);
-    layout->addWidget(line, 4, 0, 1, 3);
+    layout->addWidget(line, 5, 0, 1, 3);
 
-    layout->addWidget(new QLabel("Resolution:"), 5, 0, 1, 2, Qt::AlignCenter);
-    layout->addWidget(res, 5, 2);
+    layout->addWidget(new QLabel("Resolution:"), 6, 0, 1, 2, Qt::AlignCenter);
+    layout->addWidget(res, 6, 2);
 
-    layout->addWidget(new QLabel("Quality:"), 6, 0, 1, 2, Qt::AlignCenter);
-    layout->addWidget(quality, 6, 2);
+    layout->addWidget(new QLabel("Quality:"), 7, 0, 1, 2, Qt::AlignCenter);
+    layout->addWidget(quality, 7, 2);
 
     layout->setMargin(10);
     layout->setSpacing(4);
@@ -186,6 +189,7 @@ void SettingsPane::set(Settings s)
     zmax->setValue(s.max.z());
     res->setValue(s.res);
     quality->setValue(s.quality);
+    autobounds->setChecked(s.autobounds);
 }
 
 Settings SettingsPane::settings() const

--- a/studio/src/shape.cpp
+++ b/studio/src/shape.cpp
@@ -19,6 +19,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "studio/shape.hpp"
 #include "studio/shader.hpp"
 
+#include "libfive/solve/bounds.hpp"
+
 const int Shape::MESH_DIV_EMPTY;
 const int Shape::MESH_DIV_ABORT;
 const int Shape::MESH_DIV_NEW_VARS;
@@ -328,8 +330,27 @@ void Shape::freeGL()
 Kernel::Mesh* Shape::renderMesh(QPair<Settings, int> s)
 {
     cancel.store(false);
+
+    // Use the global bounds settings by default, but try to solve for more
+    // precise bounds if autobounds is true.
     Kernel::Region<3> r({s.first.min.x(), s.first.min.y(), s.first.min.z()},
                         {s.first.max.x(), s.first.max.y(), s.first.max.z()});
+    if (s.first.autobounds)
+    {
+        auto r_ = Kernel::findBounds(&es[0].interval);
+        if (!r_.lower.isNaN().any() &&
+            !r_.upper.isNaN().any() &&
+            ((r_.upper - r_.lower).array() / (r.upper - r.lower).array())
+                .abs().maxCoeff() < 1000)
+        {
+            r = r_;
+
+            // Add a little padding for numerical safety
+            Kernel::Region<3>::Pt diff = r.upper - r.lower;
+            r.lower -= diff / 10;
+            r.upper += diff / 10;
+        }
+    }
     auto m = Kernel::Mesh::render(es.data(), r,
             1 / (s.first.res / (1 << s.second)),
             pow(10, -s.first.quality), cancel);

--- a/studio/src/shape.cpp
+++ b/studio/src/shape.cpp
@@ -280,10 +280,12 @@ void Shape::onFutureFinished()
 {
     running = false;
 
-    auto m = mesh_future.result();
-    if (m != nullptr)
+    auto bm = mesh_future.result();
+    if (bm.first != nullptr)
     {
-        mesh.reset(mesh_future.result());
+        mesh.reset(bm.first);
+        bounds = bm.second;
+
         gl_ready = false;
         emit(gotMesh());
 
@@ -327,7 +329,7 @@ void Shape::freeGL()
 
 ////////////////////////////////////////////////////////////////////////////////
 // This function is called in a separate thread:
-Kernel::Mesh* Shape::renderMesh(QPair<Settings, int> s)
+Shape::BoundedMesh Shape::renderMesh(QPair<Settings, int> s)
 {
     cancel.store(false);
 
@@ -354,5 +356,5 @@ Kernel::Mesh* Shape::renderMesh(QPair<Settings, int> s)
     auto m = Kernel::Mesh::render(es.data(), r,
             1 / (s.first.res / (1 << s.second)),
             pow(10, -s.first.quality), cancel);
-    return m.release();
+    return {m.release(), r};
 }

--- a/studio/src/view.cpp
+++ b/studio/src/view.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 View::View(QWidget* parent)
     : QOpenGLWidget(parent), camera(size()),
-      settings({-10, -10, -10}, {10, 10, 10}, 10, 8)
+      settings(Settings::defaultSettings())
 {
     setMouseTracking(true);
 

--- a/studio/src/view.cpp
+++ b/studio/src/view.cpp
@@ -284,7 +284,27 @@ void View::paintGL()
 
     if (show_bbox)
     {
-        bbox.draw(settings.min, settings.max, camera);
+        // This is intentionally accidentally quadratic, as we won't
+        // be drawing too many bounding boxes and QVector3D doesn't
+        // come with operator< or qHash overloads.
+        QList<QPair<QVector3D, QVector3D>> shown;
+        auto draw_bbox = [&](QVector3D min, QVector3D max){
+            if (!shown.contains({min, max}))
+            {
+                bbox.draw(min, max, camera);
+                shown.push_back({min, max});
+            }
+        };
+        for (auto& s : shapes)
+        {
+            auto b = s->getBounds();
+            draw_bbox(QVector3D(b.lower.x(), b.lower.y(), b.lower.z()),
+                      QVector3D(b.upper.x(), b.upper.y(), b.upper.z()));
+        }
+        if (shapes.size() == 0)
+        {
+            draw_bbox(settings.min, settings.max);
+        }
     }
 
     if (drag_target)


### PR DESCRIPTION
This PR uses `Kernel::findBounds` to automatically extract bounds for shapes (if "autobounds" is checked in the settings pane).  The auto-extracted bounds are used if they're within 1000x of the manually-specified bounds, to work around cases where `findBounds` overestimates by huge amounts.

The rendered bounding boxes accurately reflect the bounds used in meshing, so it's easy to debug and see how well `findBounds` is doing.

This change breaks compatibility of the `#! RENDER ...` comment, which should be manually edited to add a trailing ` / 1 `, e.g.

```#! RENDER -1.3 -0.7 -4.7 / 1.3 0.8 1 / 1 / 1 !#```
should become
```#! RENDER -1.3 -0.7 -4.7 / 1.3 0.8 1 / 1 / 1 / 1 !#```

(you could also add a trailing ` / 0 ` instead, to disable this feature)
