### PR TITLE
Add support for Qt 5.6 (and older Mac OS X) for Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 ################################################################################
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -g -fPIC -pedantic -Werror=switch -march=native")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -g -fPIC -pedantic -Werror=switch -march=native -stdlib=libc++")
 set(CMAKE_CXX_FLAGS_RELEASE  "-O3 -DRELEASE -DEIGEN_NO_DEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG    "-O0")
 

--- a/studio/src/documentation.cpp
+++ b/studio/src/documentation.cpp
@@ -140,7 +140,7 @@ DocumentationPane::DocumentationPane()
     auto completer = new QCompleter(fs.keys());
     completer->setCaseSensitivity(Qt::CaseInsensitive);
     search->setCompleter(completer);
-    connect(completer, QOverload<const QString&>::of(&QCompleter::highlighted),
+    connect(completer, static_cast<void (QCompleter::*)(const QString&)>(&QCompleter::highlighted),
             txt, [=](const QString& str){
                 if (tags.count(str))
                 {

--- a/studio/src/interpreter.cpp
+++ b/studio/src/interpreter.cpp
@@ -261,7 +261,7 @@ Interpreter::Interpreter()
     busy_timer.setSingleShot(true);
     busy_timer.setInterval(100);
     connect(&eval_timer, &QTimer::timeout, &busy_timer,
-            QOverload<>::of(&QTimer::start));
+            static_cast<void (QTimer::*)()>(&QTimer::start));
     connect(&busy_timer, &QTimer::timeout, this, &Interpreter::busy);
     connect(&interpreter, &_Interpreter::gotResult,
             &busy_timer, [&](QString){ busy_timer.stop(); });

--- a/studio/src/settings.cpp
+++ b/studio/src/settings.cpp
@@ -157,7 +157,7 @@ SettingsPane::SettingsPane(Settings s)
 
     for (auto t : {xmin, xmax, ymin, ymax, zmin, zmax, res, quality})
     {
-        connect(t, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+        connect(t, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
                 this, [=](double){ emit(this->changed(settings())); });
         connect(this, &SettingsPane::enable,
                 t, [=](){ t->setReadOnly(false); });

--- a/studio/src/view.cpp
+++ b/studio/src/view.cpp
@@ -98,9 +98,9 @@ void View::setShapes(QList<Shape*> new_shapes)
             connect(s, &Shape::redraw, this, &View::update);
             connect(s, &Shape::gotMesh, this, &View::checkMeshes);
             connect(s, &Shape::gotMesh, &pick_timer,
-                    QOverload<>::of(&QTimer::start));
+                    static_cast<void (QTimer::*)()>(&QTimer::start));
             connect(this, &View::startRender,
-                    s, QOverload<Settings>::of(&Shape::startRender));
+                    s, static_cast<void (Shape::*)(Settings)>(&Shape::startRender));
             s->startRender(settings);
             s->setParent(this);
 

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -134,8 +134,8 @@ Window::Window(QString target)
     show_bbox_action->setCheckable(true);
     connect(show_bbox_action, &QAction::triggered, view, &View::showBBox);
 
-    auto perspective_action = new QAction("Perspective");
-    auto ortho_action = new QAction("Orthographic");
+    auto perspective_action = new QAction("Perspective", nullptr);
+    auto ortho_action = new QAction("Orthographic", nullptr);
     view_menu->addSection("Projection");
     view_menu->addAction(perspective_action);
     view_menu->addAction(ortho_action);
@@ -151,10 +151,10 @@ Window::Window(QString target)
             view, &View::toOrthographic);
 
     view_menu->addSeparator();
-    auto edit_bounds_action = new QAction("Edit bounds");
+    auto edit_bounds_action = new QAction("Edit bounds", nullptr);
     view_menu->addAction(edit_bounds_action);
     connect(edit_bounds_action, &QAction::triggered, view, &View::openSettings);
-    auto zoom_to_action = new QAction("Zoom to bounds");
+    auto zoom_to_action = new QAction("Zoom to bounds", nullptr);
     view_menu->addAction(zoom_to_action);
     connect(zoom_to_action, &QAction::triggered, view, &View::zoomTo);
 


### PR DESCRIPTION
Hi,

This PR "backports" Studio to Qt 5.6-compatible syntax (from the existing Qt 5.7 syntax) to enable building with Qt 5.6 and also includes a small compiler flag addition to enable compilation on older Mac OS X versions (e.g. 10.8.5).

One benefit from being Qt 5.6-compatible is that that version is a ["Long Term Support" release supported until March 16, 2019](http://doc.qt.io/qt-5/supported-platforms-and-configurations.html#qt-5-6) whereas [Qt 5.7 official support finished June 15, 2017](http://doc.qt.io/qt-5/supported-platforms-and-configurations.html#qt-5-7).

(The next [LTS release is Qt 5.9 until May 31, 2020](http://doc.qt.io/qt-5/supported-platforms-and-configurations.html#qt-5-9) but that drops support for Mac OS X 10.8 & 10.9.)

Working on the assumption that the plans for Studio aren't going to be pushing Qt too hard, I think supporting Qt 5.6 would enable the widest audience for the project. But I am biased. :)

Thanks for considering this PR.