### PR TITLE
Add blend-clearance-inset

### DIFF
--- a/libfive/bind/csg.scm
+++ b/libfive/bind/csg.scm
@@ -48,6 +48,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   Expands shape b by the given offset then subtracts it from shape a"
   (difference a (offset b o)))
 
+(define-public (blend-clearance-inset a b o s)
+	"blend-clearance-inset a b o s
+	Smooth-subtracts (with smoothness s)
+	the offset (by o) of shape b, from shape a,
+	then includes shape b as well"
+	(values
+		(blend-difference a (offset b o) s)
+		b
+	)
+)
+
 (define-public (shell shape o)
   "shell shape o
   Returns a shell of a shape with the given offset"


### PR DESCRIPTION
This is a function I like, to insert a shape into the surface of another one, with a smooth bevel surrounding it, as though pressing a marble partway into soft clay.

I'm admittedly unsure about whether this is getting too specific for a general CSG library, or whether you'd like to offer as much to the user as possible? (I'm also not certain whether its usage would be obvious just from reading it, especially with this name. Maybe "dimple inset"?)