### PR TITLE
Fix for blend-difference

### DIFF
--- a/libfive/bind/csg.scm
+++ b/libfive/bind/csg.scm
@@ -61,7 +61,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 (define-public (blend-difference a b m)
   "blend-difference a b m
   Blends the subtraction of b from a"
-  (blend (- 0 a) b m))
+  (- (blend (- a) b m)))
 
 (define-public (morph a b m)
   "morph a b m


### PR DESCRIPTION
Just found a subtle but important oversight in how I'd written blend-difference; it worked fine if used alone, but if nested, subsequent ones would be added instead of subtracted because the signs were reversed. This should be right now, sorry about the mistake; a function like this is a bit abstract to be sure about at a glance. :)

(I also got rid of the extraneous zero while I was in there.)