### PR TITLE
Replace blend-poly with blend-expt-unit

### DIFF
--- a/libfive/bind/csg.scm
+++ b/libfive/bind/csg.scm
@@ -71,7 +71,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   with the blend term adjusted to produce results approximately
   resembling blend-rough for values between 0 and 1."
   (blend-expt a b
-    (/ 2 (expt m 2))
+    (/ 2.75 (expt m 2))
   )
 )
 

--- a/libfive/bind/csg.scm
+++ b/libfive/bind/csg.scm
@@ -53,13 +53,27 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   Returns a shell of a shape with the given offset"
   (clearance shape shape o))
 
-(define-public (blend-poly a b k)
-  "blend-poly a b m
-  Blends two shapes by the given amount using a polynomial"
-  (lambda-shape (x y z)
-    (let ((h (clamp (+ 0.5 (* 0.5 (- b a) (/ k))) 0 1)))
-      (- (mix b a h)
-         (* k h (- 1 h))))))
+(define-public (blend-expt a b m)
+  "blend-expt a b m
+  Blends two shapes by the given amount using exponents"
+  (/
+    (- (log (+
+      (exp (* (- m) a ) )
+      (exp (* (- m) b ) )
+    )))
+    m
+  )
+)
+
+(define-public (blend-expt-unit a b m)
+  "blend-expt-unit a b m
+  Blends two shapes by the given amount using exponents,
+  with the blend term adjusted to produce results approximately
+  resembling blend-rough for values between 0 and 1."
+  (blend-expt a b
+    (/ 2 (expt m 2))
+  )
+)
 
 (define-public (blend-rough a b m)
   "blend a b m
@@ -67,7 +81,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   CSG approximation that may not preserve gradients"
   (union a b (- (+ (sqrt (abs a)) (sqrt (abs b))) m)))
 
-(define-public blend blend-poly)
+(define-public blend blend-expt-unit)
 
 (define* (blend-difference a b m #:optional (o 0))
   "blend-difference a b m [o]


### PR DESCRIPTION
- Removes `blend-poly`, since it was seemingly incompatible with the auto-bounds system
- Replaces it with `blend-expt`, which has yet to demonstrate any downsides (beyond being 50% slower than `blend-rough`)
- Aliases `blend` to `blend-expt-unit`, which transforms the `m` term to produce similar-looking results to if that value had been passed to `blend-rough`

Let me know if there's anything you'd prefer to have done differently. Also let me know what needs to be done to change the description of `blend-rough` that appears in the shape reference window, as it's not correct, but I can't find where the program is drawing its current description from...