### PR TITLE
Rename norm to len

### DIFF
--- a/libfive/bind/transforms.scm
+++ b/libfive/bind/transforms.scm
@@ -170,7 +170,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   Repels the shape away from a point based upon a radius r,
   with optional exaggeration e"
   (define (falloff point)
-    (- 1 (* e (exp (- (/ (norm point) r))))))
+    (- 1 (* e (exp (- (/ (len point) r))))))
   (let ((shapep (move shape (- locus))))
     (move
      (remap-shape
@@ -189,7 +189,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   Attracts the shape towards a point based upon a radius r,
   with optional exaggeration e"
   (define (falloff point)
-    (+ 1 (* e (exp (- (/ (norm point) r))))))
+    (+ 1 (* e (exp (- (/ (len point) r))))))
   (let ((shapep (move shape (- locus))))
     (move
      (remap-shape

--- a/libfive/bind/vec.scm
+++ b/libfive/bind/vec.scm
@@ -59,10 +59,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   (vec2 (/ (slot-ref a 'x) b)
         (/ (slot-ref a 'y) b)))
 
-(define-method (norm (a <vec2>))
+(define-method (len (a <vec2>))
   (sqrt (+ (expt (.x a) 2)
            (expt (.y a) 2))))
-(export norm)
+(export len)
 
 (define-method (dot (a <vec2>) (b <vec2>))
   (+ (* (.x a) (.x b))
@@ -131,11 +131,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         (- (* (.x a) (.y b)) (* (.y a) (.x b)))))
 (export cross)
 
-(define-method (norm (a <vec3>))
+(define-method (len (a <vec3>))
   (sqrt (+ (expt (.x a) 2)
            (expt (.y a) 2)
            (expt (.z a) 2))))
-(export norm)
+(export len)
 
 (define-method (dot (a <vec3>) (b <vec3>))
   (+ (* (.x a) (.x b))


### PR DESCRIPTION
Was preparing a new function based on `attract`, and realised that the function `norm` doesn't normalize vectors, it just returns their lengths. Thought I would rename it to save other people this confusion in the future, and for the sake of people looking for a vector length function (I had written my own because I didn't realise this already was one!)