### PR TITLE
Use OpenGL 3.2 rather than 3.3.

### DIFF
--- a/studio/gl/bars.frag
+++ b/studio/gl/bars.frag
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 in vec3 base_pos;
 uniform float fade;

--- a/studio/gl/basic.frag
+++ b/studio/gl/basic.frag
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 uniform vec4 color_mul;
 uniform vec4 color_add;

--- a/studio/gl/basic.vert
+++ b/studio/gl/basic.vert
@@ -1,4 +1,5 @@
-#version 330
+#version 150
+#extension GL_ARB_explicit_attrib_location : require
 
 layout(location=0) in vec3 vertex_position;
 layout(location=1) in vec3 vertex_color;

--- a/studio/gl/busy.frag
+++ b/studio/gl/busy.frag
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 in vec3 base_pos;
 uniform float time;

--- a/studio/gl/line.vert
+++ b/studio/gl/line.vert
@@ -1,4 +1,5 @@
-#version 330
+#version 150
+#extension GL_ARB_explicit_attrib_location : require
 
 layout(location=0) in vec2 vertex_position;
 

--- a/studio/src/main.cpp
+++ b/studio/src/main.cpp
@@ -27,9 +27,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 int main(int argc, char** argv)
 {
-    {   // Configure default OpenGL as 3.3 Core
+    {   // Configure default OpenGL as 3.2 Core
         QSurfaceFormat format;
-        format.setVersion(3, 3);
+        format.setVersion(3, 2);
         format.setProfile(QSurfaceFormat::CoreProfile);
         format.setSamples(8);
         QSurfaceFormat::setDefaultFormat(format);


### PR DESCRIPTION
This enables the OpenGL version check to pass on Mac OS X 10.8 (see #113).

Note:
We don't change the shader language version because apparently Mac OS X "mostly" supports GLSL 3.30 as well. And changing the shader version to 1.50 doesn't work due to use of `location`.

It's possible this "version mismatch" could cause issues on other systems but, you know, WFM. :)

(Ideally we'd handle this without the version mismatch but other approaches I can think of seem more complicated...)