### PR TITLE
Fix to GL context check.

### DIFF
--- a/studio/src/view.cpp
+++ b/studio/src/view.cpp
@@ -222,7 +222,7 @@ void View::redrawPicker()
 
     // We may not have the OpenGL context, so we claim it here
     // (and release it at the bottom if it was claimed)
-    const bool needs_gl = (context() == QOpenGLContext::currentContext());
+    const bool needs_gl = !(context() == QOpenGLContext::currentContext());
     if (needs_gl)
     {
         makeCurrent();


### PR DESCRIPTION
Fixed the check for the GL context in redrawPicker.
Fixes issue #93.