### PR TITLE
Added a libfive Guile 'console' application.

### DIFF
--- a/libfive/bind/CMakeLists.txt
+++ b/libfive/bind/CMakeLists.txt
@@ -3,9 +3,18 @@ ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/bundle.cpp
     DEPENDS libfive-guile.cpp shapes.scm csg.scm transforms.scm text.scm util.scm vec.scm
             sandbox.scm ${CMAKE_CURRENT_SOURCE_DIR}/bundle.cmake)
 
+# five-guile library
 add_library(five-guile SHARED ${CMAKE_CURRENT_BINARY_DIR}/bundle.cpp)
 target_link_libraries(five-guile five ${GUILE_LIBRARIES})
 target_include_directories(five-guile PUBLIC . ${GUILE_INCLUDE_DIRS})
+
+# five-guile-console utility
+if(UNIX AND NOT(APPLE))
+    add_executable(five-guile-console five-guile-console.cpp)
+    target_link_libraries(five-guile-console five five-guile ${GUILE_LIBRARIES})
+    target_include_directories(five-guile-console PUBLIC . ${GUILE_INCLUDE_DIRS})
+    install(TARGETS five-guile-console DESTINATION bin)
+endif(UNIX AND NOT(APPLE))
 
 if(UNIX)
     install(TARGETS five-guile DESTINATION lib)

--- a/libfive/bind/five-guile-console.cpp
+++ b/libfive/bind/five-guile-console.cpp
@@ -1,0 +1,23 @@
+#include <libguile.h>
+#include "libfive-guile.h"
+
+static void guile_main (void *data, int argc, char *argv[])
+{
+    static_cast<void>(data); // avoid unused parameter warning
+
+    scm_init_libfive_modules();
+    scm_c_use_module("libfive kernel");
+    scm_c_use_module("libfive vec");
+    scm_c_use_module("libfive csg");
+    scm_c_use_module("libfive shapes");
+    scm_c_use_module("libfive util");
+    scm_c_use_module("libfive sandbox");
+    scm_shell (argc, argv);
+}
+
+int main (int argc, char *argv[])
+{
+    scm_boot_guile (argc, argv, guile_main, 0);
+
+    return 0;
+}


### PR DESCRIPTION
I developed this simple Guile CLI when I was working on a Common Lisp binding to libfive.  It is based on the libfive Guile test code.  I used it as a reference when diagnosing problems.  It allowed me to evaluate libfive Guile code without compiling Studio.  It can be used with ```rlwrap``` for command recall/editing.  If you think it might be useful to others, please feel free to add it.
