### PR TITLE
Rewrite serialization + deserialization

### DIFF
--- a/libfive/include/libfive/tree/archive.hpp
+++ b/libfive/include/libfive/tree/archive.hpp
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #pragma once
 
 #include <map>
+
 #include "libfive/tree/tree.hpp"
 
 namespace Kernel {
@@ -31,6 +32,9 @@ public:
 
     /*
      *  Adds a new shape to the archive
+     *
+     *  The shape has an optional name and docstring, plus a map of
+     *  variables to names.
      */
     void addShape(Tree tree, std::string name="", std::string doc="",
                   std::map<Tree::Id, std::string> vars=
@@ -39,12 +43,12 @@ public:
     /*
      *  Serialize to a set of raw bytes
      */
-    std::vector<uint8_t> serialize() const;
+    void serialize(std::ostream& out);
 
     /*
      *  Deserialize from a set of raw bytes
      */
-    static Archive deserialize(const std::vector<uint8_t>& data);
+    static Archive deserialize(std::istream& in);
 
     /*  Stores a tree, plus metadata to describe it.
      *  This could be used to store shape functions, e.g.
@@ -63,79 +67,6 @@ public:
 
     /* Here's the actual data stored in the Archive */
     std::list<Shape> shapes;
-
-    /**************************************************************************
-     *  HELPER FUNCTIONS
-     *  These are exposed to make things like Oracle serialization easier.
-     *************************************************************************/
-
-    /*
-     *  Serialize a string, wrapping in quotes and escaping with backslash
-     *  This is exposed as a public function so Oracles can more easily
-     *  serialize their names, etc.
-     */
-    static void serializeString(const std::string& s, std::vector<uint8_t>& out);
-
-    /*
-     *  Serialize an arbitrary set of bytes
-     */
-    template <typename T>
-    static void serializeBytes(T t, std::vector<uint8_t>& out)
-    {
-        for (unsigned i=0; i < sizeof(t); ++i)
-        {
-            out.push_back(((uint8_t*)&t)[i]);
-        }
-    }
-
-    /*
-     *  Deserializes a string, handling escaped characters
-     *  Moves pos along, returning early if it hits end
-     */
-    static std::string deserializeString(const uint8_t*& pos,
-                                         const uint8_t* end);
-
-    template <typename T>
-    static T deserializeBytes(const uint8_t*& pos, const uint8_t* end)
-    {
-        T t;
-        for (unsigned i=0; i < sizeof(t) && pos < end; ++i)
-        {
-            ((uint8_t*)&t)[i] = *pos++;
-        }
-        return t;
-    }
-
-protected:
-
-    /*
-     *  Serialize a Tree and all of its dependencies.
-     */
-    static void serializeTree(Tree t, std::vector<uint8_t>& out,
-                            std::map<Tree::Id, uint32_t>& ids);
-
-    /*
-     *  Writes a tree to the given output stream.
-     *
-     *  Uses the ids map to only serialize trees that haven't already been
-     *  stored.  This can be a problem if the root of the tree was already
-     *  stored; in that case, it uses the lower-case 't' identifier to point
-     *  back at the id.
-     */
-    void serializeShape(const Shape& s, std::vector<uint8_t>& out,
-                        std::map<Tree::Id, uint32_t>& ids) const;
-
-    /*
-     *  Deserializes a Shape, moving pos along.
-     */
-    static Shape deserializeShape(const uint8_t*& pos, const uint8_t* end,
-                                  std::map<uint32_t, Tree>& ts);
-
-    /*  
-     *  We use this flag to end a data stream, either of 
-     *  the tree of a shape or its vars.
-     */
-    static const uint8_t END_OF_ITEM;
 };
 
 }   // namespace Kernel

--- a/libfive/include/libfive/tree/deserializer.hpp
+++ b/libfive/include/libfive/tree/deserializer.hpp
@@ -1,6 +1,6 @@
 /*
 libfive: a CAD kernel for modeling with implicit functions
-Copyright (C) 2017  Matt Keeter
+Copyright (C) 2018  Matt Keeter
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -17,37 +17,44 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include <iostream>
-#include <cassert>
+#include <map>
 
 #include "libfive/tree/archive.hpp"
-#include "libfive/tree/serializer.hpp"
-#include "libfive/tree/deserializer.hpp"
 
-namespace Kernel
+namespace Kernel {
+
+class Deserializer
 {
-void Archive::addShape(Tree tree, std::string name, std::string doc,
-                       std::map<Tree::Id, std::string> vars)
-{
-    Shape s;
-    s.tree = tree;
-    s.name = name;
-    s.doc = doc;
-    s.vars = vars;
+public:
+    Deserializer(std::istream& in)
+        : in(in)
+    { /* Nothing to do here */ }
 
-    shapes.push_back(s);
-}
+    /*
+     *  Main deserialization function
+     */
+    Archive run();
 
-////////////////////////////////////////////////////////////////////////////////
+    /*  Helper functions */
+    std::string deserializeString();
+    template <typename T> T deserializeBytes()
+    {
+        T t;
+        in.read(reinterpret_cast<char*>(&t), sizeof(t));
+        return t;
+    }
 
-void Archive::serialize(std::ostream& out)
-{
-    Serializer(out).run(*this);
-}
+    /*  This is the parallel map to Serializer::ids */
+    std::map<uint32_t, Tree> trees;
 
-Archive Archive::deserialize(std::istream& data)
-{
-    return Deserializer(data).run();
-}
+protected:
+    /*
+     *  Deserializes a Shape
+     */
+    Archive::Shape deserializeShape();
 
+    std::istream& in;
+    Archive archive;
+};
 
 }   // namespace Kernel

--- a/libfive/include/libfive/tree/deserializer.hpp
+++ b/libfive/include/libfive/tree/deserializer.hpp
@@ -51,7 +51,7 @@ protected:
     /*
      *  Deserializes a Shape
      */
-    Archive::Shape deserializeShape();
+    Archive::Shape deserializeShape(char tag);
 
     std::istream& in;
     Archive archive;

--- a/libfive/include/libfive/tree/serializer.hpp
+++ b/libfive/include/libfive/tree/serializer.hpp
@@ -1,0 +1,82 @@
+/*
+libfive: a CAD kernel for modeling with implicit functions
+Copyright (C) 2018  Matt Keeter
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include <iostream>
+#include <map>
+
+#include "libfive/tree/archive.hpp"
+
+namespace Kernel {
+
+class Serializer
+{
+public:
+    Serializer(std::ostream& out)
+        : out(out)
+    { /* Nothing to do here */ }
+
+    /*
+     *  Main serialization function
+     */
+    void run(Archive& a);
+
+    /*
+     *  Serialize a string, wrapping in quotes and escaping with backslash
+     *  This is exposed as a public function so Oracles can more easily
+     *  serialize their names, etc.
+     */
+    void serializeString(const std::string& s);
+
+    /*
+     *  Serialize / deserialize an arbitrary object as raw bytes
+     */
+    template <typename T> void serializeBytes(T t)
+    {
+        out.write(reinterpret_cast<char*>(&t), sizeof(t));
+    }
+
+    /*  This variable maps between Tree ids and positions within
+     *  the serialized data stream, so we can skip trees that
+     *  have already been serialized.  */
+    std::map<Tree::Id, uint32_t> ids;
+
+    /*  We use this flag to end a data stream, either of
+     *  the tree of a shape or its vars.  */
+    static const uint8_t END_OF_ITEM;
+
+protected:
+    /*
+     *  Serialize a Tree and all of its dependencies.
+     *  Modifies the ids map to store where each subtree has been serialized.
+     */
+    void serializeTree(Tree t);
+
+    /*
+     *  Writes a tree to the given output stream.
+     *
+     *  Uses the ids map to only serialize trees that haven't already been
+     *  stored.  This can be a problem if the root of the tree was already
+     *  stored; in that case, it uses the lower-case 't' identifier to point
+     *  back at the id.
+     */
+    void serializeShape(const Archive::Shape& s);
+
+    std::ostream& out;
+};
+
+}   // namespace Kernel

--- a/libfive/include/libfive/tree/transformed_oracle_clause.hpp
+++ b/libfive/include/libfive/tree/transformed_oracle_clause.hpp
@@ -46,12 +46,8 @@ public:
 
     std::vector<Kernel::Tree> dependencies() const override;
 
-    bool serialize(std::vector<uint8_t>& data,
-                   std::map<Tree::Id, uint32_t>& ids) const;
-    static std::unique_ptr<const OracleClause> deserialize(
-      const uint8_t*& pos, const uint8_t* end,
-      std::map<uint32_t, Tree>& ts);
-protected:
+    bool serialize(Serializer& out) const;
+    static std::unique_ptr<const OracleClause> deserialize(Deserializer& in);
 
 private:
     Tree underlying;

--- a/libfive/include/libfive/tree/tree.hpp
+++ b/libfive/include/libfive/tree/tree.hpp
@@ -169,15 +169,8 @@ public:
      */
     std::list<Tree> ordered() const;
 
-    /*
-     *  Serializes to a vector of bytes
-     */
-    std::vector<uint8_t> serialize() const;
-
-    /*
-     *  Deserialize a tree from a set of bytes
-     */
-    static Tree deserialize(const std::vector<uint8_t>& data);
+    void serialize(std::ostream& out) const;
+    static Tree deserialize(std::istream& in);
 
     /*
      *  Loads a tree from a file

--- a/libfive/src/CMakeLists.txt
+++ b/libfive/src/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(five SHARED
     tree/cache.cpp
     tree/opcode.cpp
     tree/archive.cpp
+    tree/deserializer.cpp
+    tree/serializer.cpp
     tree/tree.cpp
     tree/oracle_clause.cpp
     tree/transformed_oracle_clause.cpp

--- a/libfive/src/libfive.cpp
+++ b/libfive/src/libfive.cpp
@@ -125,12 +125,11 @@ void libfive_tree_delete(libfive_tree ptr)
 
 bool libfive_tree_save(libfive_tree ptr, const char* filename)
 {
-    auto data = ptr->serialize();
     std::ofstream out;
     out.open(filename, std::ios::out|std::ios::binary);
     if (out.is_open())
     {
-        out.write((const char*)&data[0], data.size());
+        ptr->serialize(out);
         return true;
     }
     else

--- a/libfive/src/tree/deserializer.cpp
+++ b/libfive/src/tree/deserializer.cpp
@@ -52,6 +52,7 @@ Archive::Shape Deserializer::deserializeShape(char tag)
     { \
         std::cerr << "Deserializer: expected " << #cond \
                   << " at deserializer.cpp:" << __LINE__ << std::endl; \
+        throw std::to_string(__LINE__);\
     }
 #define CHECK_POS() REQUIRE(!in.eof())
 
@@ -70,7 +71,7 @@ Archive::Shape Deserializer::deserializeShape(char tag)
     }
     else
     {
-        while (!in.eof())
+        while (true)
         {
             CHECK_POS();
 
@@ -78,6 +79,10 @@ Archive::Shape Deserializer::deserializeShape(char tag)
             // and the vars
             const uint8_t op_ = deserializeBytes<uint8_t>();
             if (op_ == Serializer::END_OF_ITEM)
+            {
+                break;
+            }
+            else if (in.eof())
             {
                 break;
             }

--- a/libfive/src/tree/deserializer.cpp
+++ b/libfive/src/tree/deserializer.cpp
@@ -40,8 +40,8 @@ Archive::Shape Deserializer::deserializeShape()
 #define REQUIRE(cond) \
     if (!(cond)) \
     { \
-        std::cerr << "Archive::deserialize: expected " << #cond \
-                  << " at " << __LINE__ << std::endl; \
+        std::cerr << "Error: expected " << #cond \
+                  << " at deserializer.cpp:" << __LINE__ << std::endl; \
     }
 #define CHECK_POS() REQUIRE(!in.eof())
 
@@ -120,7 +120,7 @@ Archive::Shape Deserializer::deserializeShape()
         }
         out.tree = trees.at(trees.size() - 1);
     }
-    while (in.eof())
+    while (!in.eof())
     {
         CHECK_POS();
 

--- a/libfive/src/tree/deserializer.cpp
+++ b/libfive/src/tree/deserializer.cpp
@@ -1,0 +1,183 @@
+/*
+libfive: a CAD kernel for modeling with implicit functions
+Copyright (C) 2018  Matt Keeter
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include <iostream>
+#include <map>
+
+#include "libfive/tree/deserializer.hpp"
+#include "libfive/tree/serializer.hpp"
+
+namespace Kernel {
+
+Archive Deserializer::run()
+{
+    Archive out;
+
+    while (!in.eof())
+    {
+        out.shapes.push_back(deserializeShape());
+    }
+    return out;
+}
+
+Archive::Shape Deserializer::deserializeShape()
+{
+#define REQUIRE(cond) \
+    if (!(cond)) \
+    { \
+        std::cerr << "Archive::deserialize: expected " << #cond \
+                  << " at " << __LINE__ << std::endl; \
+    }
+#define CHECK_POS() REQUIRE(!in.eof())
+
+    CHECK_POS();
+    char tag;
+    in.get(tag);
+    REQUIRE(tag == 'T' || tag == 't');
+    CHECK_POS();
+
+    Archive::Shape out;
+    out.name = deserializeString();
+    CHECK_POS();
+    out.doc = deserializeString();
+
+    if (tag == 't')
+    {
+        auto root = deserializeBytes<uint32_t>();
+        out.tree = trees.at(root);
+    }
+    else
+    {
+        while (!in.eof())
+        {
+            CHECK_POS();
+
+            // Check for END_OF_ITEM as a demarcation between the Tree
+            // and the vars
+            const uint8_t op_ = deserializeBytes<uint8_t>();
+            if (op_ == Serializer::END_OF_ITEM)
+            {
+                break;
+            }
+
+            auto op = Opcode::Opcode(op_);
+
+            REQUIRE(op > Opcode::INVALID);
+            REQUIRE(op < Opcode::LAST_OP);
+            CHECK_POS();
+
+            auto args = Opcode::args(op);
+            auto next = trees.size();
+            if (op == Opcode::CONSTANT)
+            {
+                float v = deserializeBytes<float>();
+                trees.insert({next, Tree(v)});
+            }
+            else if (op == Opcode::ORACLE)
+            {
+                std::string name = deserializeString();
+                CHECK_POS();
+                auto o = OracleClause::deserialize(name, *this);
+                if (o.get() == nullptr)
+                {
+                    std::cerr
+                        << "Archive::deserialize: failed to deserialize Oracle \""
+                        << name << "\"" << std::endl;
+                    return out;
+                }
+                trees.insert({next, Tree(std::move(o))});
+            }
+            else if (args == 2)
+            {
+                auto rhs = deserializeBytes<uint32_t>();
+                auto lhs = deserializeBytes<uint32_t>();
+                trees.insert({next, Tree(op, trees.at(lhs), trees.at(rhs))});
+            }
+            else if (args == 1)
+            {
+                auto lhs = deserializeBytes<uint32_t>();
+                trees.insert({next, Tree(op, trees.at(lhs))});
+            }
+            else
+            {
+                trees.insert({next, Tree(op)});
+            }
+        }
+        out.tree = trees.at(trees.size() - 1);
+    }
+    while (in.eof())
+    {
+        CHECK_POS();
+
+        // Check for END_OF_ITEM as a demarcation between Shapes
+        const uint8_t op_ = deserializeBytes<uint8_t>();
+        if (op_ == Serializer::END_OF_ITEM)
+        {
+            break;
+        }
+
+        auto varName = deserializeString();
+        auto idx = deserializeBytes<uint32_t>();
+        auto t = trees.find(idx);
+        REQUIRE(t != trees.end());
+        REQUIRE(out.vars.find(t->second.id()) == out.vars.end());
+        out.vars[t->second.id()] = varName;
+    }
+    return out;
+}
+
+std::string Deserializer::deserializeString()
+{
+    std::string out;
+    if (in.eof())
+    {
+        std::cerr << "Archive::deserializeString: EOF at beginning of string"
+                  << std::endl;
+    }
+    else if (in.get() != '"')
+    {
+        std::cerr << "Archive::deserializeString: expected opening \""
+                  << std::endl;
+    }
+    else
+    {
+        while (!in.eof())
+        {
+            char c = in.get();
+            if (c == '"')
+            {
+                break;
+            }
+            else if (c == '\\')
+            {
+                if (!in.eof())
+                {
+                    out.push_back(in.get());
+                }
+            }
+            else
+            {
+                out.push_back(c);
+            }
+        }
+    }
+    return out;
+}
+
+
+}   // namespace Kernel

--- a/libfive/src/tree/deserializer.cpp
+++ b/libfive/src/tree/deserializer.cpp
@@ -40,7 +40,7 @@ Archive::Shape Deserializer::deserializeShape()
 #define REQUIRE(cond) \
     if (!(cond)) \
     { \
-        std::cerr << "Error: expected " << #cond \
+        std::cerr << "Deserializer: expected " << #cond \
                   << " at deserializer.cpp:" << __LINE__ << std::endl; \
     }
 #define CHECK_POS() REQUIRE(!in.eof())
@@ -96,7 +96,7 @@ Archive::Shape Deserializer::deserializeShape()
                 if (o.get() == nullptr)
                 {
                     std::cerr
-                        << "Archive::deserialize: failed to deserialize Oracle \""
+                        << "Deserializer: failed to deserialize Oracle \""
                         << name << "\"" << std::endl;
                     return out;
                 }
@@ -146,12 +146,12 @@ std::string Deserializer::deserializeString()
     std::string out;
     if (in.eof())
     {
-        std::cerr << "Archive::deserializeString: EOF at beginning of string"
+        std::cerr << "Deserializer::deserializeString: EOF at beginning of string"
                   << std::endl;
     }
     else if (in.get() != '"')
     {
-        std::cerr << "Archive::deserializeString: expected opening \""
+        std::cerr << "Deserializer::deserializeString: expected opening \""
                   << std::endl;
     }
     else

--- a/libfive/src/tree/deserializer.cpp
+++ b/libfive/src/tree/deserializer.cpp
@@ -28,14 +28,24 @@ Archive Deserializer::run()
 {
     Archive out;
 
-    while (!in.eof())
+    while(1)
     {
-        out.shapes.push_back(deserializeShape());
+        char tag;
+        in.get(tag);
+
+        if (!in.eof())
+        {
+            out.shapes.push_back(deserializeShape(tag));
+        }
+        else
+        {
+            break;
+        }
     }
     return out;
 }
 
-Archive::Shape Deserializer::deserializeShape()
+Archive::Shape Deserializer::deserializeShape(char tag)
 {
 #define REQUIRE(cond) \
     if (!(cond)) \
@@ -46,10 +56,7 @@ Archive::Shape Deserializer::deserializeShape()
 #define CHECK_POS() REQUIRE(!in.eof())
 
     CHECK_POS();
-    char tag;
-    in.get(tag);
     REQUIRE(tag == 'T' || tag == 't');
-    CHECK_POS();
 
     Archive::Shape out;
     out.name = deserializeString();

--- a/libfive/src/tree/oracle_clause.cpp
+++ b/libfive/src/tree/oracle_clause.cpp
@@ -7,8 +7,7 @@
 namespace Kernel {
 
 std::unique_ptr<const OracleClause> OracleClause::deserialize(
-        const std::string& name, const uint8_t*& pos, const uint8_t* end,
-        std::map<uint32_t, Tree>& ts)
+        const std::string& name, Deserializer& in)
 {
     auto itr = installed().find(name);
     if (itr == installed().end())
@@ -21,13 +20,12 @@ std::unique_ptr<const OracleClause> OracleClause::deserialize(
     }
     else
     {
-        return (*itr).second.second(pos, end, ts);
+        return (*itr).second.second(in);
     }
 }
 
 bool OracleClause::serialize(const std::string& name,
-        const OracleClause* clause, std::vector<uint8_t>& data,
-         std::map<Tree::Id, uint32_t>& ids)
+        const OracleClause* clause, Serializer& out)
 {
     auto itr = installed().find(name);
     if (itr == installed().end())
@@ -40,7 +38,7 @@ bool OracleClause::serialize(const std::string& name,
     }
     else
     {
-        return (*itr).second.first(clause, data, ids);
+        return (*itr).second.first(clause, out);
     }
 }
 

--- a/libfive/src/tree/serializer.cpp
+++ b/libfive/src/tree/serializer.cpp
@@ -1,0 +1,129 @@
+/*
+libfive: a CAD kernel for modeling with implicit functions
+Copyright (C) 2018  Matt Keeter
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include <iostream>
+#include <map>
+
+#include "libfive/tree/serializer.hpp"
+
+namespace Kernel {
+
+const uint8_t Serializer::END_OF_ITEM = 0xFF;
+
+void Serializer::run(Archive& a)
+{
+    static_assert(Opcode::LAST_OP <= 254, "Too many opcodes");
+
+    for (const auto& s : a.shapes)
+    {
+        serializeShape(s);
+    }
+}
+
+void Serializer::serializeTree(Tree t)
+{
+    for (auto& n : t.ordered())
+    {
+        // Skip this id, as it has already been stored
+        if (ids.find(n.id()) != ids.end())
+        {
+            continue;
+        }
+        if (n->op == Opcode::ORACLE)
+        {
+            assert(n->oracle.get() != nullptr);
+            for (auto& d : n->oracle->dependencies())
+            {
+                serializeTree(d);
+            }
+        }
+        out.put(n->op);
+        ids.insert({ n.id(), (uint32_t)ids.size() });
+
+        // Write constants as raw bytes
+        if (n->op == Opcode::CONSTANT)
+        {
+            serializeBytes(n->value);
+        }
+        else if (n->op == Opcode::ORACLE)
+        {
+            assert(n->oracle.get() != nullptr);
+            serializeString(n->oracle->name());
+            OracleClause::serialize(n->oracle->name(), n->oracle.get(), *this);
+        }
+
+        switch (Opcode::args(n->op))
+        {
+            case 2:  serializeBytes(ids.at(n->rhs.get())); // FALLTHRU
+            case 1:  serializeBytes(ids.at(n->lhs.get())); // FALLTHRU
+            default: break;
+        }
+    }
+}
+
+void Serializer::serializeShape(const Archive::Shape& s)
+{
+    // 'T' indicate a fully-serialized tree;
+    // 't' indicates an id pointing to an earlier tree.
+    const bool already_stored = ids.find(s.tree.id()) != ids.end();
+    out.put(already_stored ? 't' : 'T');
+
+    serializeString(s.name);
+    serializeString(s.doc);
+
+    if (already_stored)
+    {
+        serializeBytes(ids.at(s.tree.id()));
+    }
+    else
+    {
+        serializeTree(s.tree);
+        out.put(END_OF_ITEM);
+    }
+    for (auto& v : s.vars)
+    {
+        auto a = ids.find(v.first);
+        if (a == ids.end())
+        {
+            std::cerr << "Archive::serialize: named variable not found.";
+        }
+        else
+        {
+            serializeString(v.second);
+            serializeBytes(a->second);
+        }
+    }
+    out.put(END_OF_ITEM);
+}
+
+void Serializer::serializeString(const std::string& s)
+{
+    out.put('"');
+    for (auto& c : s)
+    {
+        if (c == '"' || c == '\\')
+        {
+            out.put('\\');
+        }
+        out.put(c);
+    }
+    out.put('"');
+}
+
+
+}   // namespace Kernel

--- a/libfive/src/tree/transformed_oracle_clause.cpp
+++ b/libfive/src/tree/transformed_oracle_clause.cpp
@@ -18,7 +18,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "libfive/tree/transformed_oracle_clause.hpp"
 #include "libfive/eval/transformed_oracle.hpp"
-#include "libfive/tree/archive.hpp"
+
+#include "libfive/tree/serializer.hpp"
+#include "libfive/tree/deserializer.hpp"
 
 namespace Kernel {
 
@@ -55,13 +57,12 @@ std::vector<Kernel::Tree> TransformedOracleClause::dependencies() const
     return { underlying, X_, Y_, Z_ };
 }
 
-bool TransformedOracleClause::serialize(std::vector<uint8_t>& data,
-     std::map<Tree::Id, uint32_t>& ids) const
+bool TransformedOracleClause::serialize(Serializer& out) const
 {
-    auto serializeId = [&data, &ids](Tree t)
+    auto serializeId = [&out](Tree t)
     {
-      assert(ids.find(t.id()) != ids.end());
-      Archive::serializeBytes(ids[t.id()], data);
+      assert(out.ids.find(t.id()) != ids.end());
+      out.serializeBytes(out.ids[t.id()]);
     };
     serializeId(underlying);
     serializeId(X_);
@@ -71,13 +72,12 @@ bool TransformedOracleClause::serialize(std::vector<uint8_t>& data,
 }
 
 std::unique_ptr<const OracleClause> TransformedOracleClause::deserialize(
-    const uint8_t*& pos, const uint8_t* end,
-    std::map<uint32_t, Tree>& ts)
+        Deserializer& in)
 {
-    auto deserializeId = [&pos, &end, &ts]()
+    auto deserializeId = [&in]()
     {
-        auto idx = Archive::deserializeBytes<uint32_t>(pos, end);
-        auto location = ts.find(idx);
+        auto idx = in.deserializeBytes<uint32_t>();
+        auto location = in.trees.find(idx);
         assert(location != ts.end());
         return location->second;
     };

--- a/libfive/src/tree/tree.cpp
+++ b/libfive/src/tree/tree.cpp
@@ -148,7 +148,7 @@ Tree Tree::deserialize(std::istream& in)
 
 Tree Tree::load(const std::string& filename)
 {
-    std::ifstream in(filename, std::ios::in|std::ios::binary|std::ios::ate);
+    std::ifstream in(filename, std::ios::in|std::ios::binary);
     return in.is_open() ? deserialize(in) : Tree();
 }
 

--- a/libfive/src/tree/tree.cpp
+++ b/libfive/src/tree/tree.cpp
@@ -134,14 +134,14 @@ std::list<Tree> Tree::ordered() const
     return out;
 }
 
-std::vector<uint8_t> Tree::serialize() const
+void Tree::serialize(std::ostream& out) const
 {
-    return Archive(*this).serialize();
+    return Archive(*this).serialize(out);
 }
 
-Tree Tree::deserialize(const std::vector<uint8_t>& data)
+Tree Tree::deserialize(std::istream& in)
 {
-    auto s = Archive::deserialize(data).shapes;
+    auto s = Archive::deserialize(in).shapes;
     assert(s.size() == 1);
     return s.front().tree;
 }
@@ -149,17 +149,7 @@ Tree Tree::deserialize(const std::vector<uint8_t>& data)
 Tree Tree::load(const std::string& filename)
 {
     std::ifstream in(filename, std::ios::in|std::ios::binary|std::ios::ate);
-    if (in.is_open())
-    {
-        std::vector<uint8_t> data;
-        data.resize(in.tellg());
-
-        in.seekg(0, std::ios::beg);
-        in.read((char*)&data[0], data.size());
-
-        return deserialize(data);
-    }
-    return Tree();
+    return in.is_open() ? deserialize(in) : Tree();
 }
 
 Tree Tree::remap(Tree X_, Tree Y_, Tree Z_) const

--- a/libfive/test/archive.cpp
+++ b/libfive/test/archive.cpp
@@ -19,6 +19,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "catch.hpp"
 
 #include "libfive/tree/archive.hpp"
+#include "libfive/tree/serializer.hpp"
+#include "libfive/tree/deserializer.hpp"
+
 #include "libfive/tree/oracle_clause.hpp"
 #include "libfive/eval/oracle.hpp"
 
@@ -30,21 +33,15 @@ public:
     std::string name() const override { return "ST"; }
     std::unique_ptr<Oracle> getOracle() const override { return nullptr; }
 
-    bool serialize(std::vector<uint8_t>& data,
-                   std::map<Tree::Id, uint32_t>& ids) const
+    bool serialize(Serializer& out) const
     {
-        (void)ids;
-        Archive::serializeString("hi", data);
+        out.serializeString("hi");
         return true;
     }
 
-    static std::unique_ptr<const OracleClause> deserialize(
-            const uint8_t*& pos, const uint8_t* end,
-            std::map<uint32_t, Tree>& ts)
+    static std::unique_ptr<const OracleClause> deserialize(Deserializer& in)
     {
-        (void)ts;
-
-        auto out = Archive::deserializeString(pos, end);
+        auto out = in.deserializeString();
         if (out != "hi")
         {
             return nullptr;
@@ -62,10 +59,11 @@ TEST_CASE("Archive::serialize")
     {
         auto a = Archive();
         a.addShape(min(Tree::X(), Tree::Y()), "hi");
-        auto out = a.serialize();
-        std::vector<uint8_t> expected =
-            {'T', '"', 'h', 'i', '"', '"', '"', Opcode::VAR_X, Opcode::VAR_Y, Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF};
-        REQUIRE(out == expected);
+        std::stringstream out;
+        a.serialize(out);
+        std::string expected =
+            {'T', '"', 'h', 'i', '"', '"', '"', Opcode::VAR_X, Opcode::VAR_Y, Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, (char)0xFF, (char)0xFF};
+        REQUIRE(out.str() == expected);
     }
 
     SECTION("Multiple independent trees")
@@ -73,14 +71,16 @@ TEST_CASE("Archive::serialize")
         auto a = Archive();
         a.addShape(min(Tree::X(), Tree::Y()));
         a.addShape(max(Tree::X(), Tree::Y()));
-        auto out = a.serialize();
-        std::vector<uint8_t> expected =
+
+        std::stringstream out;
+        a.serialize(out);
+        std::string expected =
             {'T', '"', '"', '"', '"',
                 Opcode::VAR_X, Opcode::VAR_Y,
-                Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF,
+                Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, (char)0xFF, (char)0xFF,
              'T', '"', '"', '"', '"',
-                Opcode::OP_MAX, 1, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF};
-        REQUIRE(out == expected);
+                Opcode::OP_MAX, 1, 0, 0, 0, 0, 0, 0, 0, (char)0xFF, (char)0xFF};
+        REQUIRE(out.str() == expected);
     }
 
     SECTION("Trees with already-stored root")
@@ -88,34 +88,43 @@ TEST_CASE("Archive::serialize")
         auto a = Archive();
         a.addShape(min(Tree::X(), Tree::Y()));
         a.addShape(Tree::X());
-        auto out = a.serialize();
-        std::vector<uint8_t> expected =
+
+        std::stringstream out;
+        a.serialize(out);
+
+        std::string expected =
             {'T', '"', '"', '"', '"',
                 Opcode::VAR_X, Opcode::VAR_Y,
-                Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF,
+                Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, (char)0xFF, (char)0xFF,
              't', '"', '"', '"', '"',
-                0, 0, 0, 0, 0xFF};
-        REQUIRE(out == expected);
+                0, 0, 0, 0, (char)0xFF};
+        REQUIRE(out.str() == expected);
     }
 
     SECTION("String escaping")
     {
         auto a = Archive();
         a.addShape(min(Tree::X(), Tree::Y()), "hi", "\"\\");
-        auto out = a.serialize();
-        std::vector<uint8_t> expected =
-            {'T', '"', 'h', 'i', '"', '"', '\\', '"', '\\', '\\', '"', Opcode::VAR_X, Opcode::VAR_Y, Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF};
-        REQUIRE(out == expected);
+
+        std::stringstream out;
+        a.serialize(out);
+
+        std::string expected =
+            {'T', '"', 'h', 'i', '"', '"', '\\', '"', '\\', '\\', '"', Opcode::VAR_X, Opcode::VAR_Y, Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, (char)0xFF, (char)0xFF};
+        REQUIRE(out.str() == expected);
     }
 
     SECTION("With an oracle")
     {
         auto a = Archive(Tree(std::unique_ptr<OracleClause>(
                         new ST())));
-        auto out = a.serialize();
-        std::vector<uint8_t> expected =
-            {'T', '"', '"', '"', '"', Opcode::ORACLE, '"', 'S', 'T', '"', '"', 'h', 'i', '"', 0xFF, 0xFF};
-        REQUIRE(out == expected);
+
+        std::stringstream out;
+        a.serialize(out);
+
+        std::string expected =
+            {'T', '"', '"', '"', '"', Opcode::ORACLE, '"', 'S', 'T', '"', '"', 'h', 'i', '"', (char)0xFF, (char)0xFF};
+        REQUIRE(out.str() == expected);
     }
 }
 
@@ -123,8 +132,10 @@ TEST_CASE("Archive::deserialize")
 {
     SECTION("Oracle")
     {
-        std::vector<uint8_t> in =
+        std::string s =
                 {'T', '"', '"', '"', '"', Opcode::ORACLE, '"', 'S', 'T', '"', '"', 'h', 'i', '"'};
+
+        std::stringstream in(s);
         auto t = Archive::deserialize(in).shapes.front();
         REQUIRE(t.tree.id() != nullptr);
         REQUIRE(t.tree->op == Opcode::ORACLE);
@@ -139,9 +150,12 @@ TEST_CASE("Archive::deserialize")
                 "With a \"docstring\"");
         a.addShape(Tree::X(), "HELLO");
         a.addShape(Tree::Z() + Tree::X() + min(Tree::X(), Tree::Y()));
-        auto out = a.serialize();
 
-        auto b = Archive::deserialize(out);
+        std::stringstream out;
+        a.serialize(out);
+
+        std::stringstream in(out.str());
+        auto b = Archive::deserialize(in);
         REQUIRE(b.shapes.size() == a.shapes.size());
 
         auto a_itr = a.shapes.begin();

--- a/libfive/test/tree.cpp
+++ b/libfive/test/tree.cpp
@@ -56,19 +56,22 @@ TEST_CASE("Tree::serialize")
     SECTION("Basic")
     {
         auto a = min(Tree::X(), Tree::Y());
-        auto out = a.serialize();
-        std::vector<uint8_t> expected =
-            {'T', '"', '"', '"', '"', Opcode::VAR_X, Opcode::VAR_Y, Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF};
-        REQUIRE(out == expected);
+        std::stringstream out;
+        a.serialize(out);
+
+        std::string expected =
+            {'T', '"', '"', '"', '"', Opcode::VAR_X, Opcode::VAR_Y, Opcode::OP_MIN, 1, 0, 0, 0, 0, 0, 0, 0, (char)0xFF, (char)0xFF};
+        REQUIRE(out.str() == expected);
     }
 
     SECTION("With local references")
     {
         auto a = min(Tree::X(), Tree::X());
-        auto out = a.serialize();
-        std::vector<uint8_t> expected =
-            {'T', '"', '"', '"', '"', Opcode::VAR_X, Opcode::OP_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF};
-        REQUIRE(out == expected);
+        std::stringstream out;
+        a.serialize(out);
+        std::string expected =
+            {'T', '"', '"', '"', '"', Opcode::VAR_X, Opcode::OP_MIN, 0, 0, 0, 0, 0, 0, 0, 0, (char)0xFF, (char)0xFF};
+        REQUIRE(out.str() == expected);
     }
 }
 
@@ -76,7 +79,12 @@ TEST_CASE("Tree::deserialize")
 {
     SECTION("Simple")
     {
-        auto a = Tree::deserialize(min(Tree::X(), Tree::Y()).serialize());
+        std::stringstream out;
+        min(Tree::X(), Tree::Y()).serialize(out);
+
+        std::stringstream in(out.str());
+        auto a = Tree::deserialize(in);
+
         REQUIRE(a.id() != nullptr);
         REQUIRE(a->op == Opcode::OP_MIN);
         REQUIRE(a->lhs->op == Opcode::VAR_X);
@@ -85,7 +93,12 @@ TEST_CASE("Tree::deserialize")
 
     SECTION("With constant")
     {
-        auto a = Tree::deserialize(min(Tree::X(), Tree(2.5f)).serialize());
+        std::stringstream out;
+        min(Tree::X(), Tree(2.5f)).serialize(out);
+
+        std::stringstream in(out.str());
+        auto a = Tree::deserialize(in);
+
         REQUIRE(a.id() != nullptr);
         REQUIRE(a->op == Opcode::OP_MIN);
         REQUIRE(a->lhs->op == Opcode::VAR_X);
@@ -95,7 +108,12 @@ TEST_CASE("Tree::deserialize")
 
     SECTION("With variable")
     {
-        auto a = Tree::deserialize(min(Tree::X(), Tree::var()).serialize());
+        std::stringstream out;
+        min(Tree::X(), Tree::var()).serialize(out);
+
+        std::stringstream in(out.str());
+        auto a = Tree::deserialize(in);
+
         REQUIRE(a.id() != nullptr);
         REQUIRE(a->op == Opcode::OP_MIN);
         REQUIRE(a->lhs->op == Opcode::VAR_X);


### PR DESCRIPTION
This moves serialization and deserialization out of the Archive class (which becomes a bag of labelled shapes), and cleans up the API for Oracles to serialize/deserialize themselves.