### PR TITLE
Fix apparent typo in libfive Guile module.

### DIFF
--- a/libfive/bind/libfive-guile.cpp
+++ b/libfive/bind/libfive-guile.cpp
@@ -506,7 +506,7 @@ void init_libfive_kernel(void*)
  )");
 
     scm_c_export(
-            "shape?", "shape", "wrap-shape", "unwrap-shape",
+            "shape?", "<shape>", "wrap-shape", "unwrap-shape",
             "make-shape", "make-var", "var?", "shape-tree-id", "number->shape",
             "shape-equal?", "shape-eval", "shape->mesh", "shape-meta",
             "save-shape", "load-shape",


### PR DESCRIPTION
This PR exports `<shape>` so it can be used as a class outside the libfive package.

Currently if you first do this [procedure](https://github.com/libfive/libfive/blob/master/doc/guide.md#working-from-the-guile-command-line),

then:

    (use-modules (oop goops))

Now try to define a method:

    (define-method (shape->mesh-data (s <shape>)
                                     (r <list>)
                                     (res <number>))
      (format #t "shape: ~a region: ~a resolution: ~a~%" s r res))

Guile returns:

    ...In procedure module-lookup: Unbound variable: <shape>...

After applying this PR, the method can be defined and works.