### PR TITLE
set locale encoding to prevent degree symbol from breaking unit tests

### DIFF
--- a/libfive/bind/text.scm
+++ b/libfive/bind/text.scm
@@ -407,8 +407,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                      (* pi 1.5))
            #[0 0.75] )))
 
-;(make-glyph! #\° 0.4
-;  (ring 0.175 0.075 #[0.2 0.8]))
+(make-glyph! #\° 0.4
+  (ring 0.175 0.075 #[0.2 0.8]))
 
 (make-glyph! #\# 0.55
   (move (shear-x-y  (union (rectangle #[0.1 0.05] #[0.2 0.75])

--- a/libfive/test/guile.cpp
+++ b/libfive/test/guile.cpp
@@ -33,6 +33,7 @@ static std::string eval(std::string input) {
     if (!initialized)
     {
         scm_init_guile();
+        std::setlocale(LC_CTYPE, "en_US.UTF-8");
         scm_init_libfive_modules();
         scm_c_use_module("libfive kernel");
         scm_c_use_module("libfive vec");


### PR DESCRIPTION
This should fix #161 . The locale encoding is set to "en_US.UTF-8" so that the C string for the "text.scm" binding is evaluated correctly in  [libfive-guile.cpp](https://github.com/libfive/libfive/blob/master/libfive/bind/libfive-guile.cpp).
