### PR TITLE
 Added 'libfive_contours3' alternate contour format to the C API. 

### DIFF
--- a/libfive/include/libfive.h
+++ b/libfive/include/libfive.h
@@ -75,6 +75,25 @@ typedef struct libfive_contours {
 } libfive_contours;
 
 /*
+ *  libfive_contour3 is a single 2D contour, consisting of a sequence of
+ *  3D points plus a count of how many points are stored
+ */
+typedef struct libfive_contour3 {
+    libfive_vec3* pts;
+    uint32_t count;
+} libfive_contour3;
+
+/*
+ *  libfive_contours3 is a set of 2D contours, consisting of multiple
+ *  libfive_contour3 objects and a count of how many are stored
+ */
+typedef struct libfive_contours3 {
+    libfive_contour3* cs;
+    uint32_t count;
+} libfive_contours3;
+
+
+/*
  *  libfive_mesh is an indexed 3D mesh.
  *  There are vert_count vertices, and tri_count triangles.
  */
@@ -115,6 +134,11 @@ typedef struct libfive_pixels {
  *  Frees an libfive_contours data structure
  */
 void libfive_contours_delete(libfive_contours* cs);
+
+/*
+ *  Frees an libfive_contours data structure
+ */
+void libfive_contours3_delete(libfive_contours3* cs);
 
 /*
  *  Frees an libfive_mesh data structure
@@ -282,6 +306,13 @@ char* libfive_tree_print(libfive_tree t);
 libfive_contours* libfive_tree_render_slice(libfive_tree tree,
                                             libfive_region2 R,
                                             float z, float res);
+/*
+ *  Renders a tree to a set of contours, similar to libfive_tree_render_slice,
+ *  except the contours are 3D points (see the libfive_contour3 struct) above.
+ */
+libfive_contours3* libfive_tree_render_slice3(libfive_tree tree,
+                                              libfive_region2 R,
+                                              float z, float res);
 
 /*
  *  Renders and saves a slice to a file

--- a/libfive/src/libfive.cpp
+++ b/libfive/src/libfive.cpp
@@ -33,6 +33,16 @@ void libfive_contours_delete(libfive_contours* cs)
     delete cs;
 }
 
+void libfive_contours3_delete(libfive_contours3* cs)
+{
+    for (unsigned i=0; i < cs->count; ++i)
+    {
+        delete [] cs->cs[i].pts;
+    }
+    delete [] cs->cs;
+    delete cs;
+}
+
 void libfive_mesh_delete(libfive_mesh* m)
 {
     delete [] m->verts;
@@ -228,6 +238,36 @@ libfive_contours* libfive_tree_render_slice(libfive_tree tree,
         for (auto& pt : c)
         {
             out->cs[i].pts[j++] = {pt.x(), pt.y()};
+        }
+        i++;
+    }
+
+    return out;
+}
+
+libfive_contours3* libfive_tree_render_slice3(libfive_tree tree,
+                                              libfive_region2 R, float z, float res)
+{
+    Region<2> region({R.X.lower, R.Y.lower}, {R.X.upper, R.Y.upper},
+            Region<2>::Perp(z));
+    auto cs = Contours::render(*tree, region, 1/res);
+
+    auto out = new libfive_contours3;
+    out->count = cs->contours.size();
+    out->cs = new libfive_contour3[out->count];
+
+    size_t i=0;
+    for (auto& c : cs->contours)
+    {
+        out->cs[i].count = c.size();
+        out->cs[i].pts = new libfive_vec3[c.size()];
+
+        size_t j=0;
+        for (auto& pt : c)
+        {
+          // each 2D contour point is converted to a 3D point (with
+          // this function's z argument as the Z coordinate)
+          out->cs[i].pts[j++] = {pt.x(), pt.y(), z};
         }
         i++;
     }


### PR DESCRIPTION
This alternate contour format is directly supported in Open Inventor (e.g. the SoLineSet node class). This will allow the Clive, PyInventor, and Pivy Open Inventor bindings to use Libfive C API contours without conversion.
