### PR TITLE
Fixed env error in export-meshes

### DIFF
--- a/bin/export-meshes
+++ b/bin/export-meshes
@@ -1,4 +1,4 @@
-#!/usr/bin/env guile --no-auto-compile -s
+#!/usr/bin/env -S guile --no-auto-compile -s
 
 This is a headless, minimal version of Studio.
 


### PR DESCRIPTION
This fixes #235. Please make sure the script still works on your system, as I'm not sure since what version of the coreutils the `-S` option exists.