### PR TITLE
fixes for contour multithreading: effect of multithreadng boolean was…

### DIFF
--- a/libfive/include/libfive/render/brep/contours.hpp
+++ b/libfive/include/libfive/render/brep/contours.hpp
@@ -37,6 +37,16 @@ public:
         std::atomic_bool& cancel, unsigned workers);
 
     /*
+     *  Full-featured render function without cancel, to prevent
+     *  an accidentally-left-out cancel boolean from causing the
+     *  worker count to autoconvert to the multithreading boolean.
+     */
+    static std::unique_ptr<Contours> render(
+      const Tree t, const Region<2>& r,
+      double min_feature, double max_err,
+      unsigned workers);
+
+    /*
      *  Saves the contours to an SVG file
      */
     bool saveSVG(const std::string& filename);

--- a/libfive/src/render/brep/contours.cpp
+++ b/libfive/src/render/brep/contours.cpp
@@ -190,8 +190,17 @@ std::unique_ptr<Contours> Contours::render(const Tree t,
                                            double max_err /*= 1e-8*/,
                                            bool multithread /*= true*/)
 {
-    std::atomic_bool cancel(false);
-    return render(t, r, min_feature, max_err, cancel, multithread ? 1 : 8);
+  return render(t, r, min_feature, max_err, multithread ? 8u : 1u);
+}
+
+std::unique_ptr<Contours> Contours::render(const Tree t,
+                                           const Region<2>& r,
+                                           double min_feature /*= 0.1*/,
+                                           double max_err /*= 1e-8*/,
+                                           unsigned workers)
+{
+  std::atomic_bool cancelled(false);
+  return render(t, r, min_feature, max_err, cancelled, workers);
 }
 
 }   // namespace Kernel


### PR DESCRIPTION
… backward, and there could be accidental conversion from leaving out the cancellation boolean