### PR TITLE
Fix gcc on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if(NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -g -fPIC -pedantic -Werror=switch -march=native")
-    if (APPLE)
+    if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++")

--- a/libfive/include/libfive/oracle/transformed_oracle_clause.hpp
+++ b/libfive/include/libfive/oracle/transformed_oracle_clause.hpp
@@ -46,4 +46,4 @@ private:
     Tree Z_;
 };
 
-}; //namespace Kernel
+} //namespace Kernel

--- a/libfive/src/oracle/transformed_oracle_clause.cpp
+++ b/libfive/src/oracle/transformed_oracle_clause.cpp
@@ -15,7 +15,7 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 
 namespace Kernel {
 
-REGISTER_ORACLE_CLAUSE(TransformedOracleClause);
+REGISTER_ORACLE_CLAUSE(TransformedOracleClause)
 
 TransformedOracleClause::TransformedOracleClause(
         Tree underlying, Tree X_, Tree Y_, Tree Z_)
@@ -80,4 +80,4 @@ std::unique_ptr<const OracleClause> TransformedOracleClause::deserialize(
             new TransformedOracleClause(underlying, X_, Y_, Z_));
 }
 
-}; //namespace Kernel
+} //namespace Kernel

--- a/libfive/src/render/brep/dc/dc_tree2.cpp
+++ b/libfive/src/render/brep/dc/dc_tree2.cpp
@@ -56,7 +56,6 @@ const std::vector<std::pair<uint8_t, uint8_t>>& DCTree<2>::edges() const
 }
 
 // Explicit initialization of template
-template class XTree<2, DCTree<2>, DCLeaf<2>>;
 template class DCTree<2>;
 
 }   // namespace Kernel

--- a/libfive/test/archive.cpp
+++ b/libfive/test/archive.cpp
@@ -40,7 +40,7 @@ public:
         return std::unique_ptr<const OracleClause>(new ST());
     }
 };
-REGISTER_ORACLE_CLAUSE(ST);
+REGISTER_ORACLE_CLAUSE(ST)
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Hey Matt,

I got two errors when trying to build libfive using g++ on my Mac.

1. An unsupported flag `-stdlib=libc++` was used. This happened since the root CMakeLists.txt equated using a Mac with using clang. My fix assumes you meant to test for clang and Mac, but you could change it to `${CMAKE_CXX_COMPILER_ID} MATCHES "AppleClang"` instead.

2. There were symbols with multiple definitions since `XTree<2, DCTree<2>, DCLeaf<2>>` was instantiated in both `dc_tree2.cpp` and `dc_xtree.cpp`. This is fixed by removing the instantiation in `dc_tree2.cpp`, which doesn't seem to be used.

I also removed some unnecessary semicolons that were generating warnings (as a result of compiling with `-pedantic`).

I built and tested this branch using three different configurations. On mac with clang, one test fails as expected (transformed_oracle). On Mac or Linux with g++, two tests fail as expected (transformed_oracle and simplex) and one test fails. This is the same behavior I see on `master`, compiled with g++ on Linux. (The failing test is in `qef.cpp` which evaluates to `-0.0 > 0` in line 243.) 