### PR TITLE
Find git hash for truly out of source builds

### DIFF
--- a/libfive/src/CMakeLists.txt
+++ b/libfive/src/CMakeLists.txt
@@ -4,7 +4,14 @@
 ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.c
            ${CMAKE_CURRENT_BINARY_DIR}/_version.c
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake)
+    # Pass the current source dir to version.cmake, so that it can run git
+    # commands there instead of in the binary dir. This enables it to find
+    # the right info when the build dir is outside the libfive repo.
+    COMMAND ${CMAKE_COMMAND}
+        -DLIBFIVE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DFIVE_DLL")

--- a/libfive/src/version.cmake
+++ b/libfive/src/version.cmake
@@ -1,5 +1,8 @@
+# The variable LIBFIVE_CURRENT_SOURCE_DIR should be defined for this script.
+
 execute_process(COMMAND git log --pretty=format:'%h' -n 1
                 OUTPUT_VARIABLE GIT_REV
+                WORKING_DIRECTORY ${LIBFIVE_CURRENT_SOURCE_DIR}
                 ERROR_QUIET)
 
 # Check whether we got any revision (which isn't always the case, e.g.
@@ -11,12 +14,15 @@ if ("${GIT_REV}" STREQUAL "")
     set(GIT_BRANCH "N/A")
 else()
     execute_process(COMMAND bash -c "git diff --quiet --exit-code || echo +"
-                    OUTPUT_VARIABLE GIT_DIFF)
+                    OUTPUT_VARIABLE GIT_DIFF
+                    WORKING_DIRECTORY ${LIBFIVE_CURRENT_SOURCE_DIR})
     execute_process(COMMAND git describe --exact-match --tags
                     OUTPUT_VARIABLE GIT_TAG
+                    WORKING_DIRECTORY ${LIBFIVE_CURRENT_SOURCE_DIR}
                     ERROR_QUIET)
     execute_process(COMMAND git rev-parse --abbrev-ref HEAD
-                    OUTPUT_VARIABLE GIT_BRANCH)
+                    OUTPUT_VARIABLE GIT_BRANCH
+                    WORKING_DIRECTORY ${LIBFIVE_CURRENT_SOURCE_DIR})
 
     string(STRIP "${GIT_REV}" GIT_REV)
     string(SUBSTRING "${GIT_REV}" 1 7 GIT_REV)


### PR DESCRIPTION
Currently the git commands used to generate `version.c` are run from the build directory, which might not be a subdirectory of the libfive repo. I propose running them from the source directory instead.

I noticed this since I'm building libfive as a submodule, and it was picking up the parent project's hash and branch. Even when libfive isn't a submodule, now the git info won't end up being "N/A" if the build dir is outside the repo.