### PR TITLE
refactoring atomic types for compilation with GCC

### DIFF
--- a/libfive/include/libfive/render/brep/dual.hpp
+++ b/libfive/include/libfive/render/brep/dual.hpp
@@ -254,7 +254,7 @@ std::unique_ptr<typename M::Output> Dual<N>::walk_(
     tasks.push(t.get());
     t->resetPending();
 
-    std::atomic_uint32_t global_index(1);
+    std::atomic<uint32_t> global_index(1);
     std::vector<PerThreadBRep<N>> breps;
     for (unsigned i=0; i < workers; ++i) {
         breps.emplace_back(PerThreadBRep<N>(global_index));

--- a/libfive/include/libfive/render/brep/per_thread_brep.hpp
+++ b/libfive/include/libfive/render/brep/per_thread_brep.hpp
@@ -25,7 +25,7 @@ template <unsigned N>
 class PerThreadBRep
 {
 public:
-    PerThreadBRep(std::atomic_uint32_t& c) : c(c)
+    PerThreadBRep(std::atomic<uint32_t>& c) : c(c)
     {
         assert(c.load() == 1);
     }
@@ -55,7 +55,7 @@ public:
     std::vector<uint32_t> indices;
 
 protected:
-    std::atomic_uint32_t& c;
+    std::atomic<uint32_t>& c;
 };
 
 }   // namespace Kernel

--- a/libfive/include/libfive/render/brep/progress.hpp
+++ b/libfive/include/libfive/render/brep/progress.hpp
@@ -48,7 +48,7 @@ protected:
      *  updates at a fixed speed (e.g. 200 Hz). */
     std::timed_mutex mut;
 
-    std::atomic_uint64_t counter;
+    std::atomic<uint64_t> counter;
     const uint64_t total;
     const float offset;
 

--- a/libfive/include/libfive/render/brep/simplex/simplex_tree.hpp
+++ b/libfive/include/libfive/render/brep/simplex/simplex_tree.hpp
@@ -45,7 +45,7 @@ struct SimplexLeafSubspace {
     bool inside;
 
     /*   Global indices for subspace vertices  */
-    std::atomic_uint64_t index;
+    std::atomic<uint64_t> index;
 
     /*  Per-subspace QEF */
     QEF<N> qef;
@@ -55,7 +55,7 @@ struct SimplexLeafSubspace {
      *  at a time (since they represent shared spaces).  We use a
      *  homebrew reference counting system to avoid releasing them to
      *  the pool while they're still in use.  */
-    std::atomic_uint32_t refcount;
+    std::atomic<uint32_t> refcount;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/libfive/src/render/brep/simplex/simplex_tree.cpp
+++ b/libfive/src/render/brep/simplex/simplex_tree.cpp
@@ -708,7 +708,7 @@ using LockFreeStack = boost::lockfree::stack<
 
 template <unsigned N>
 void assignIndicesWorker(LockFreeStack<N>& tasks,
-                         std::atomic_uint64_t& index,
+                         std::atomic<uint64_t>& index,
                          std::atomic_bool& done,
                          std::atomic_bool& cancel)
 {
@@ -882,7 +882,7 @@ void SimplexTree<N>::assignIndices(unsigned workers,
     AssignIndexTask<N> first{this, std::make_shared<NeighborStack<N>>()};
     tasks.push(first);
 
-    std::atomic_uint64_t global_index(1);
+    std::atomic<uint64_t> global_index(1);
     std::atomic_bool done(false);
 
     std::vector<std::future<void>> futures;


### PR DESCRIPTION
changed atomic_uint32t and atomic_uint64t to atomic<uint32t> and atomic<uint64t> respectively
now compiles with GCC 6 on Debian GNU/Linux