### PR TITLE
Set up Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 - .travis/build-docker.sh
 
 script:
-- docker run -v $PWD:/root/libfive libfive:1
+- docker run -v $PWD:/src libfive:1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+dist: xenial
+language: minimal
+
+services:
+- docker
+
+install:
+- .travis/build-docker.sh
+
+script:
+- docker run -v $PWD:/root/libfive libfive:1

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -5,6 +5,4 @@ RUN apt-get update
 RUN apt-get install -y -qq --no-install-recommends \
     g++ cmake pkg-config libeigen3-dev libpng-dev libboost-all-dev qtbase5-dev libqt5opengl5-dev guile-2.2-dev
 
-COPY run-tests.sh /root/run-tests.sh
-
-ENTRYPOINT ["/root/run-tests.sh"]
+ENTRYPOINT ["/src/.travis/run-tests.sh"]

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:18.04
 RUN apt-get update
 
 RUN apt-get install -y -qq --no-install-recommends \
-    g++ cmake pkg-config libeigen3-dev libpng-dev libboost-all-dev qtbase5-dev libqt5opengl5-dev guile-2.2-dev
+    g++ cmake pkg-config libeigen3-dev libpng-dev libboost-all-dev qtbase5-dev libqt5opengl5-dev guile-2.2-dev locales
+
+RUN locale-gen en_US.UTF-8
 
 ENTRYPOINT ["/src/.travis/run-tests.sh"]

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+
+RUN apt-get install -y -qq --no-install-recommends \
+    g++ cmake pkg-config libeigen3-dev libpng-dev libboost-all-dev qtbase5-dev libqt5opengl5-dev guile-2.2-dev
+
+COPY run-tests.sh /root/run-tests.sh
+
+ENTRYPOINT ["/root/run-tests.sh"]

--- a/.travis/build-docker.sh
+++ b/.travis/build-docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -evuo pipefail
+
+cd $(dirname $0)
+docker build -t libfive:1 .

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -evuo pipefail
 
-mkdir -p /root/libfive/build
-cd /root/libfive/build
-cmake ..
+mkdir -p /build
+cd /build
+cmake /src
 make -j2
-./libfive/test/libfive-test
+/build/libfive/test/libfive-test

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -evuo pipefail
+
+mkdir -p /root/libfive/build
+cd /root/libfive/build
+cmake ..
+make -j2
+./libfive/test/libfive-test

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -evuo pipefail
 
+export CLICOLOR_FORCE=1
 mkdir -p /build
 cd /build
 cmake /src

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -5,4 +5,4 @@ mkdir -p /build
 cd /build
 cmake /src
 make -j2
-/build/libfive/test/libfive-test
+/build/libfive/test/libfive-test --use-colour yes


### PR DESCRIPTION
This patch set creates a CI system that installs dependencies, compiles libfive, and runs tests.

I have opted for a 'docker-in-docker' approach, because the most recent Ubuntu release supported by Travis is Ubuntu 16.04, and it is difficult to get the correct version of Guile 2.2 and Qt5 on that version. Therefore, I create a docker image with Ubuntu 18.04. I followed a similar approach to this blog post: https://agateau.com/2019/building-qt-apps-with-travis-and-docker/

Presently, the CI has two failing tests, and a number of compile warnings. See https://travis-ci.com/nickodell/libfive/builds/114044703 for details.

Fixes #255 