### PR TITLE
Compatibility with Boost 1.70

### DIFF
--- a/libfive/include/libfive/render/brep/dc/intersection.hpp
+++ b/libfive/include/libfive/render/brep/dc/intersection.hpp
@@ -35,7 +35,6 @@ bool inline Intersection<N>::operator==(const Intersection<N>& other) const
 
 template <size_t N>
 using IntersectionVec =
-        boost::container::small_vector<Intersection<N>, 4,
-            Eigen::aligned_allocator<Intersection<N>>>;
+        boost::container::small_vector<Intersection<N>, 4>;
 
 }   // namespace Kernel

--- a/libfive/src/render/brep/manifold_tables.cpp
+++ b/libfive/src/render/brep/manifold_tables.cpp
@@ -105,4 +105,4 @@ bool ManifoldTables<N>::manifold(uint32_t b)
 template class ManifoldTables<2>;
 template class ManifoldTables<3>;
 
-};
+}


### PR DESCRIPTION
As discussed in https://github.com/libfive/libfive/issues/279.

Two tests fail, and two fail as expected, which is also the behavior I see on master.