### PR TITLE
Fix unique_ptr/shared_ptr build error

### DIFF
--- a/libfive/include/libfive/render/brep/vol/vol_tree.hpp
+++ b/libfive/include/libfive/render/brep/vol/vol_tree.hpp
@@ -8,6 +8,8 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #pragma once
 
+#include <memory>
+
 #include "libfive/render/brep/xtree.hpp"
 #include "libfive/render/brep/object_pool.hpp"
 #include "libfive/render/brep/default_new_delete.hpp"


### PR DESCRIPTION
Ran into this on GCC 7.4.0 when trying to upgrade the version in Nixpkgs. Without this, it fails with `error: 'unique_ptr' in namespace 'std' does not name a template type` and likewire for `shared_ptr` at several points.