### PR TITLE
Visual studio 2019 fix

### DIFF
--- a/libfive/include/libfive/render/brep/dual.hpp
+++ b/libfive/include/libfive/render/brep/dual.hpp
@@ -236,7 +236,7 @@ std::unique_ptr<typename M::Output> Dual<N>::walk(
             const BRepSettings& settings,
             A... args)
 {
-    return Dual<N>::walk_<M>(
+    return walk_<M>(
             t, settings,
             [&args...](PerThreadBRep<N>& brep, int i) {
                 (void)i;

--- a/libfive/include/libfive/render/brep/vol/vol_tree.hpp
+++ b/libfive/include/libfive/render/brep/vol/vol_tree.hpp
@@ -8,6 +8,8 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #pragma once
 
+#include <memory>
+
 #include "libfive/render/brep/xtree.hpp"
 #include "libfive/render/brep/object_pool.hpp"
 #include "libfive/render/brep/default_new_delete.hpp"


### PR DESCRIPTION
There's a bug in visual studio 2019 that is unlikely to be prioritized because it depends on referencing a class from itself (not necessary and only done for clarity); this allows libfive to avoid the issue.