### PR TITLE
Optional vertical layout for the editor / 3D view.

### DIFF
--- a/studio/include/studio/args.hpp
+++ b/studio/include/studio/args.hpp
@@ -25,4 +25,5 @@ struct Arguments
 
     QString filename;
     bool do_syntax;
+    bool vertical;
 };

--- a/studio/src/args.cpp
+++ b/studio/src/args.cpp
@@ -31,10 +31,14 @@ Arguments::Arguments(QCoreApplication* app)
     QCommandLineOption no_syntax("no-syntax", "Turn off syntax highlighting");
     parser.addOption(no_syntax);
 
+    QCommandLineOption vertical_layout("vertical", "Use vertical layout for editor / 3D view.");
+    parser.addOption(vertical_layout);
+
     parser.process(*app);
 
     const QStringList ps = parser.positionalArguments();
     filename = ps.isEmpty() ? "" : ps[0];
 
     do_syntax = !parser.isSet(no_syntax);
+    vertical = parser.isSet(vertical_layout);
 }

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -52,10 +52,13 @@ Window::Window(Arguments args)
 
     auto layout = new QSplitter(args.vertical ? Qt::Vertical : Qt::Horizontal);
 
-    if (args.vertical) {
+    if (args.vertical)
+    {
         layout->addWidget(view);
         layout->addWidget(editor);
-    } else {
+    }
+    else
+    {
         layout->addWidget(editor);
         layout->addWidget(view);
     }

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -50,10 +50,17 @@ Window::Window(Arguments args)
 
     setAcceptDrops(true);
 
-    auto layout = new QSplitter();
-    layout->addWidget(editor);
+    auto layout = new QSplitter(args.vertical ? Qt::Vertical : Qt::Horizontal);
+
+    if (args.vertical) {
+        layout->addWidget(view);
+        layout->addWidget(editor);
+    } else {
+        layout->addWidget(editor);
+        layout->addWidget(view);
+    }
+
     editor->resize(width() * 0.4, editor->height());
-    layout->addWidget(view);
     setCentralWidget(layout);
 
     // Sync document modification state with window


### PR DESCRIPTION
This is a small change I made to Studio because I use a vertical monitor.

Starting with 'Studio --vertical' switches from the default horizontal layout.

This is my first pull request, so let me know if I have done something wrong, or you don't think this feature is required.
