### PR TITLE
Fix missing template arguments for lock

### DIFF
--- a/libfive/src/tree/cache.cpp
+++ b/libfive/src/tree/cache.cpp
@@ -18,7 +18,7 @@ int Cache::shutdown()
     auto mutPtr = mut();
     /// We can lock the mutex to at least protect against Handles that
     /// existed before the call on other threads.
-    std::unique_lock lock(*mutPtr);
+    std::unique_lock<std::recursive_mutex> lock(*mutPtr);
     auto cache = singleton();
     if (!cache->ops.empty() || !cache->constants.empty() ||
         !cache->nan_constant.expired()) {


### PR DESCRIPTION
I just noticed that it wouldn't compile on Arch with GCC 9.2.0 and this fixes it. Also tested with latest clang on Arch too.