### PR TITLE
Change calls to non-deprecated Qt functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and should also build with MinGW (though this is untested).
 - [Eigen 3.3.x](http://eigen.tuxfamily.org/index.php?title=Main_Page)
 - [`libpng`](http://www.libpng.org/pub/png/libpng.html)
 - [Boost 1.65 or later](https://www.boost.org)
-- [Qt 5.7 or later](https://www.qt.io)
+- [Qt 5.11 or later](https://www.qt.io)
 - [Guile 2.2.1 or later](https://www.gnu.org/software/guile/)
 
 Qt and Guile are optional; if they aren't present, then

--- a/studio/src/documentation.cpp
+++ b/studio/src/documentation.cpp
@@ -131,7 +131,7 @@ DocumentationPane::DocumentationPane()
         QFontMetrics fm(txt->font());
         for (auto line : txt->toPlainText().split("\n"))
         {
-            max_width = std::max(max_width, fm.width(line));
+            max_width = std::max(max_width, fm.horizontalAdvance(line));
         }
         txt->setMinimumWidth(max_width + 40);
     }

--- a/studio/src/editor.cpp
+++ b/studio/src/editor.cpp
@@ -43,7 +43,7 @@ Editor::Editor(QWidget* parent, bool do_syntax)
         QFont font;
         font.setFamily("Courier");
         QFontMetrics fm(font);
-        script->setTabStopWidth(fm.width("  "));
+        script->setTabStopDistance(fm.horizontalAdvance("  "));
         script_doc->setDefaultFont(font);
         err_doc->setDefaultFont(font);
         err->setFixedHeight(fm.height());


### PR DESCRIPTION
This requires Qt 5.11 minimum unfortunately, though it's a LTS release.

[setTabStopDistance](https://doc.qt.io/qt-5/qplaintextedit.html#tabStopDistance-prop) was introduced in 5.10 and [horizontalAdvance](https://doc.qt.io/qt-5/qfontmetrics.html#horizontalAdvance) in 5.11.

Tested on Arch Linux with latest GCC and Clang.