### PR TITLE
Add quit action (menu and shortcut)

### DIFF
--- a/studio/include/studio/window.hpp
+++ b/studio/include/studio/window.hpp
@@ -59,6 +59,7 @@ protected slots:
     bool onLoadTutorial(bool=false);
     void onShowDocs(bool=false);
     void onAutoLoad(const QString&);
+    void onQuit(bool=false);
 
     void onExportReady(QList<const libfive::Mesh*> shapes);
     void setDocs(Documentation* docs);

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -128,7 +128,7 @@ Window::Window(Arguments args)
     file_menu->addSeparator();
 
     auto quit_action = file_menu->addAction("Quit");
-    quit_action->setShortcuts({Qt::CTRL + Qt::Key_Q});
+    quit_action->setShortcuts(QKeySequence::Quit);
     connect(quit_action, &QAction::triggered, this, &Window::onQuit);
 
     // Edit menu

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -125,6 +125,12 @@ Window::Window(Arguments args)
     export_action->setShortcuts({Qt::CTRL + Qt::Key_E, Qt::Key_F7});
     connect(export_action, &QAction::triggered, this, &Window::onExport);
 
+    file_menu->addSeparator();
+
+    auto quit_action = file_menu->addAction("Quit");
+    quit_action->setShortcuts({Qt::CTRL + Qt::Key_Q});
+    connect(quit_action, &QAction::triggered, this, &Window::onQuit);
+
     // Edit menu
     auto edit_menu = menuBar()->addMenu("&Edit");
     auto undo_action = edit_menu->addAction("Undo");
@@ -668,4 +674,9 @@ void Window::onShowDocs(bool)
     {
         DocumentationPane::open();
     }
+}
+
+void Window::onQuit(bool)
+{
+    Window::close();
 }


### PR DESCRIPTION
Adds the shortcut Ctrl+Q and the menu option to close the program. 

It's more convenient and makes it possible to close Studio normally with window managers which don't draw any window decorations like i3 or awesome.