### PR TITLE
Revert "Change calls to non-deprecated Qt functions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and should also build with MinGW (though this is untested).
 - [Eigen 3.3.x](http://eigen.tuxfamily.org/index.php?title=Main_Page)
 - [`libpng`](http://www.libpng.org/pub/png/libpng.html)
 - [Boost 1.65 or later](https://www.boost.org)
-- [Qt 5.11 or later](https://www.qt.io)
+- [Qt 5.7 or later](https://www.qt.io)
 - [Guile 2.2.1 or later](https://www.gnu.org/software/guile/)
 
 Qt and Guile are optional; if they aren't present, then

--- a/studio/src/documentation.cpp
+++ b/studio/src/documentation.cpp
@@ -131,7 +131,7 @@ DocumentationPane::DocumentationPane()
         QFontMetrics fm(txt->font());
         for (auto line : txt->toPlainText().split("\n"))
         {
-            max_width = std::max(max_width, fm.horizontalAdvance(line));
+            max_width = std::max(max_width, fm.width(line));
         }
         txt->setMinimumWidth(max_width + 40);
     }

--- a/studio/src/editor.cpp
+++ b/studio/src/editor.cpp
@@ -43,7 +43,7 @@ Editor::Editor(QWidget* parent, bool do_syntax)
         QFont font;
         font.setFamily("Courier");
         QFontMetrics fm(font);
-        script->setTabStopDistance(fm.horizontalAdvance("  "));
+        script->setTabStopWidth(fm.width("  "));
         script_doc->setDefaultFont(font);
         err_doc->setDefaultFont(font);
         err->setFixedHeight(fm.height());


### PR DESCRIPTION
Allow building on Ubuntu 18.04 again

This reverts commit da79dd9480c11a660ec29c7ceacecd4fe2a3cda5.

da79dd9480c11a660ec29c7ceacecd4fe2a3cda5 raises the required Qt version to 5.11, past what is available on Ubuntu 18.04 without indicating that Ubuntu 18.04 is no longer supported.

Considering Ubuntu 18.04 is still the current LTS release (and I use it ;-) ) and that given that `QFontMetrics::width` still exists in 5.11 (and beyond) and `QFontMetrics::horizontalAdvance` are exactly equivalent, I would strongly prefer to retain Qt 5.7 compatibility.

I could also rework the pull request to use `QFontMetrics::horizontalAdvance` for qt >= 5.11 and `QFontMetrics::width` for older versions since at some point `QFontMetrics::width` will be removed.