### PR TITLE
Add guile binding at share/guile/site/libfive.scm

### DIFF
--- a/libfive/bind/CMakeLists.txt
+++ b/libfive/bind/CMakeLists.txt
@@ -9,4 +9,8 @@ target_include_directories(five-guile PUBLIC . ${GUILE_INCLUDE_DIRS})
 
 if(UNIX)
     install(TARGETS five-guile DESTINATION lib)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/libfive.scm libfive-scm-data)
+    string(REPLACE "@libfive-guile-lib-location@" "${CMAKE_INSTALL_PREFIX}/lib"
+      libfive-scm-out "${libfive-scm-data}")
+    file(WRITE "${CMAKE_INSTALL_PREFIX}/share/guile/site/libfive.scm" "${libfive-scm-out}")
 endif(UNIX)

--- a/libfive/bind/libfive.scm
+++ b/libfive/bind/libfive.scm
@@ -1,0 +1,2 @@
+(define-module (libfive))
+(load-extension "@libfive-guile-lib-location@/libfive-guile" "scm_init_libfive_modules")


### PR DESCRIPTION
Something like this seems to work, now I can do

```
(use-modules (libfive)
             (libfive kernel)
             (libfive vec)
             (libfive csg)
             (libfive shapes))
```

Fixes #336 