### PR TITLE
FIX: Add file watcher on directory

### DIFF
--- a/studio/include/studio/window.hpp
+++ b/studio/include/studio/window.hpp
@@ -59,6 +59,7 @@ protected slots:
     bool onLoadTutorial(bool=false);
     void onShowDocs(bool=false);
     void onAutoLoad(const QString&);
+    void onAutoLoadPath(const QString&);
     void onQuit(bool=false);
 
     void onExportReady(QList<const libfive::Mesh*> shapes);

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -79,6 +79,9 @@ Window::Window(Arguments args)
     // reload the file.
     connect(&watcher, &QFileSystemWatcher::fileChanged,
             this, &Window::onAutoLoad);
+    connect(&watcher, &QFileSystemWatcher::directoryChanged,
+            this, &Window::onAutoLoadPath);
+
 
     // Connect drag start + end signals, so the user can't edit
     // the script while dragging in the 3D viewport
@@ -349,10 +352,34 @@ bool Window::loadFile(QString f, bool reload)
 
 void Window::onAutoLoad(const QString&)
 {
-    if (autoreload)
+    if (QFile(filename).open(QIODevice::ReadOnly))
     {
-        Q_ASSERT(!filename.isEmpty());
-        loadFile(filename, true);
+        if (autoreload)
+        {
+            Q_ASSERT(!filename.isEmpty());
+            loadFile(filename, true);
+        }
+    }
+    else // File was deleted. Waiting for new file
+    {
+        watcher.addPath(QFileInfo(filename).path());
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void Window::onAutoLoadPath(const QString&)
+{
+    // file was created
+    if (QFile(filename).open(QIODevice::ReadOnly))
+    {
+        watcher.removePaths(watcher.directories());
+        watcher.addPath(filename);
+        if (autoreload)
+        {
+            Q_ASSERT(!filename.isEmpty());
+            loadFile(filename, true);
+        }
     }
 }
 


### PR DESCRIPTION
Some programs like vim save a temporary file and move it to the new
location.
The QFileSystemWatcher will receive the notification "deleted" on the
current file. It does not notice that a new file is being created.
This patch will also listen to the underlying directory which will also
trigger a reload when a new file is being added. This should make the
file watch function much more robust.i