### PR TITLE
FIX no rendering after startup without selecting new render method

### DIFF
--- a/studio/include/studio/view.hpp
+++ b/studio/include/studio/view.hpp
@@ -158,7 +158,7 @@ protected:
     QList<Shape*> shapes;
     bool settings_enabled=true;
     Settings settings;
-    libfive::BRepAlgorithm alg;
+    libfive::BRepAlgorithm alg = libfive::BRepAlgorithm::DUAL_CONTOURING;
 
     bool show_axes=true;
     bool show_bbox=false;


### PR DESCRIPTION
After startup the shapes wouldn't render any thing. Selecting
a different mesh algorithm in the UI would fix this issue.
The issue is that the default algorithm is not initialized. This causes
it to be sometimes '0' but sometimes it is just some random data.
When it is random data the shape doesn't get rendered and a nullptr is
being returned.

This patch default initializes the algorithm to "DUAL_CONTOURING"