### PR TITLE
 FEAT: add mechanism to "load" other files into your project

### DIFF
--- a/libfive/bind/sandbox.scm
+++ b/libfive/bind/sandbox.scm
@@ -237,7 +237,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
           ;; Extra functions from Guile's standard libraries
           '((srfi srfi-1) fold iota)
-          '((guile) inexact->exact))
+          '((guile) inexact->exact)
+          '((guile) load))
 
     ;; Default sandbox-safe functions
     all-pure-bindings))

--- a/studio/examples/convex-polygon.io
+++ b/studio/examples/convex-polygon.io
@@ -1,0 +1,44 @@
+;; This file is part of the load.io demonstration
+
+
+;; Counts windings of a polygon
+;; `vs` is a list of 2d vertices
+;; example:
+;; ```
+;; $ (polygon-windings (list [0 0] [0 1] [2 1] [1 0])) 
+;; 3
+;; ```
+;; Source:
+;; https://www.element84.com/blog/determining-the-winding-of-a-polygon-given-as-a-set-of-ordered-points
+(define (polygon-windings vs)
+  (define (compute-angle e1 e2) (* (- (.x e2) (.x e1)) (+ (.y e2) (.y e1))))
+  (define (list-rotate vs) (append (cdr vs) (list (car vs))))
+  (if (> 3 (length vs)) (error "polygon must have at least 3 vertices"))
+  (fold + 0 (map compute-angle vs (list-rotate vs)))
+)
+
+
+;; Creates a (convex) polygon shape
+;; `vs` is a list of 2d vertices
+;; `vs` must define a convex polygon. The first and last
+;; vertices are connected automaticaly.
+;; example:
+;; ```
+;; $ (convex-polygon (list [0 0] [0 1] [1 1]  [1 0]
+;; #<<shape> ...>
+;; ```
+(define (convex-polygon vs)
+  (define (half-plane a b)
+    (lambda-shape (x y z)
+      (- (* (- (.y b) (.y a)) (- x (.x a)))
+         (* (- (.x b) (.x a)) (- y (.y a))))))
+  (define (list-rotate vs) (append (cdr vs) (list (car vs))))
+  (define (reduce proc vs) (fold proc (car vs) (cdr vs)))
+  (define (proc v1 v2)
+    (if (> 0 (polygon-windings vs))
+      (half-plane v1 v2)
+      (half-plane v2 v1)
+    )
+  )
+  (reduce intersection (map proc vs (list-rotate vs)))
+)

--- a/studio/examples/load.io
+++ b/studio/examples/load.io
@@ -1,0 +1,9 @@
+(set-bounds! [-10 -10 -10] [10 10 10])
+(set-quality! 8)
+(set-resolution! 10)
+
+(load "convex-polygon.io")
+
+(extrude
+  (convex-polygon (list [0 0] [0 1] [2 1] [1 0]))
+0 1)

--- a/studio/include/studio/window.hpp
+++ b/studio/include/studio/window.hpp
@@ -19,9 +19,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #pragma once
 
 #include <QApplication>
+#include <QDateTime>
+#include <QFile>
+#include <QFileSystemWatcher>
 #include <QMainWindow>
 #include <QMessageBox>
-#include <QFileSystemWatcher>
 
 #include "studio/args.hpp"
 
@@ -80,10 +82,12 @@ protected:
     QString workingDirectory() const;
 
     bool loadFile(QString f, bool reload=false);
+    bool loadFile(QFile& f, bool reload=false);
     bool saveFile(QString f);
 
     /*  Filename of the current file, or empty string */
     QString filename;
+    QDateTime fileLastModified;
 
     /*  File watcher to check for changes to filename */
     QFileSystemWatcher watcher;

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -586,6 +586,16 @@ void Window::setFilename(const QString& f)
         setWindowFilePath(f);
     }
 
+    // change working directory (change to home if dir does not exist)
+    if (QFileInfo(filename).dir().exists())
+    {
+        QDir::setCurrent(QFileInfo(filename).dir().path());
+    }
+    else
+    {
+        QDir::setCurrent(QDir::homePath());
+    }
+
     // Store the target file as our autoreload target
     // (even though we'll only do reloading if the menu option is set)
     auto watched_files = watcher.files();
@@ -601,9 +611,7 @@ void Window::setFilename(const QString& f)
 
 QString Window::workingDirectory() const
 {
-    return (filename.startsWith(":/") || filename.isEmpty())
-        ? QDir::homePath()
-        : QFileInfo(filename).dir().absolutePath();
+    return QDir::currentPath();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Bigger project will have the need to split their content into multiple
files. This commit pass through the "load" command into the sandbox.
Also it plays with the "current_working" directory so "relative" loading
of paths work.

Additional thoughts: This does not enable `use-modules` because this will make it possible to break out of the
sandbox.
