### PR TITLE
Correct autoload only running once in some editors

### DIFF
--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -359,6 +359,13 @@ void Window::onAutoLoad(const QString&)
             Q_ASSERT(!filename.isEmpty());
             loadFile(filename, true);
         }
+
+        // Some editors don't edit but replace the file so the watcher thinks
+        // the file was deleted and the signal is only sent once.
+        // Re-watching the file is mandatory for those cases.
+        if (QFile::exists(filename)) {
+            watcher.addPath(filename);
+        }
     }
     else // File was deleted. Waiting for new file
     {


### PR DESCRIPTION
Some editors replace the file when saving that confuses QtFileSystem watcher and it captures the edition as a file deletion, meaning that it only sends the signal during the first save and then the file is un-watched.

The proposed changes re-watch the file to make sure that it subsequent changes are captured by the watcher.

[The issue can be replicated easily and is well known](https://stackoverflow.com/questions/18300376/qt-qfilesystemwatcher-signal-filechanged-gets-emited-only-once#18304496). My current setup (Linux + NeoVim) only loads once without the changes. After the changes, all editions are captured and the view is re-rendered accordingly.

Thanks