### PR TITLE
[FIX] Race condition on file watchers

### DIFF
--- a/studio/include/studio/window.hpp
+++ b/studio/include/studio/window.hpp
@@ -19,9 +19,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #pragma once
 
 #include <QApplication>
+#include <QDateTime>
+#include <QFile>
+#include <QFileSystemWatcher>
 #include <QMainWindow>
 #include <QMessageBox>
-#include <QFileSystemWatcher>
 
 #include "studio/args.hpp"
 
@@ -80,10 +82,12 @@ protected:
     QString workingDirectory() const;
 
     bool loadFile(QString f, bool reload=false);
+    bool loadFile(QFile& f, bool reload=false);
     bool saveFile(QString f);
 
     /*  Filename of the current file, or empty string */
     QString filename;
+    QDateTime fileLastModified;
 
     /*  File watcher to check for changes to filename */
     QFileSystemWatcher watcher;

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -329,11 +329,17 @@ bool Window::onRevert(bool)
 bool Window::loadFile(QString f, bool reload)
 {
     QFile file(f);
-    if (!file.open(QIODevice::ReadOnly))
+    file.open(QIODevice::ReadOnly);
+    return loadFile(file, reload);
+}
+
+bool Window::loadFile(QFile& file, bool reload)
+{
+    if (!file.isOpen())
     {
         QMessageBox m(this);
         m.setText("Failed to open file");
-        m.setInformativeText("<code>" + f + "</code><br>does not exist");
+        m.setInformativeText("<code>" + file.fileName() + "</code><br>does not exist");
         m.addButton(QMessageBox::Ok);
         m.setIcon(QMessageBox::Critical);
         m.setWindowModality(Qt::WindowModal);
@@ -342,34 +348,29 @@ bool Window::loadFile(QString f, bool reload)
     }
     else
     {
+        QFileInfo info(file);
+        fileLastModified = info.lastModified();
         editor->setScript(file.readAll(), reload);
         editor->setModified(false);
+
         return true;
     }
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void Window::onAutoLoad(const QString&)
 {
-    if (QFile(filename).open(QIODevice::ReadOnly))
+    Q_ASSERT(!filename.isEmpty());
+    QFile file(filename);
+    if (file.open(QIODevice::ReadOnly))
     {
         if (autoreload)
         {
             Q_ASSERT(!filename.isEmpty());
-            loadFile(filename, true);
+            loadFile(file, true);
         }
-
-        // Some editors don't edit but replace the file so the watcher thinks
-        // the file was deleted and the signal is only sent once.
-        // Re-watching the file is mandatory for those cases.
-        if (QFile::exists(filename)) {
-            watcher.addPath(filename);
-        }
-    }
-    else // File was deleted. Waiting for new file
-    {
-        watcher.addPath(QFileInfo(filename).path());
     }
 }
 
@@ -377,15 +378,18 @@ void Window::onAutoLoad(const QString&)
 
 void Window::onAutoLoadPath(const QString&)
 {
-    // file was created
-    if (QFile(filename).open(QIODevice::ReadOnly))
+    Q_ASSERT(!filename.isEmpty());
+    QFile file(filename);
+    file.open(QIODevice::ReadOnly);
+    QFileInfo info(file);
+
+    // file was created and is modified
+    if (file.isOpen() and fileLastModified != info.lastModified())
     {
-        watcher.removePaths(watcher.directories());
         watcher.addPath(filename);
         if (autoreload)
         {
-            Q_ASSERT(!filename.isEmpty());
-            loadFile(filename, true);
+            loadFile(file, true);
         }
     }
 }
@@ -596,6 +600,7 @@ void Window::setFilename(const QString& f)
     if (!filename.startsWith(":/") && !filename.isEmpty())
     {
         watcher.addPath(filename);
+        watcher.addPath(QFileInfo(filename).path());
     }
 }
 


### PR DESCRIPTION
This fixes a race condition with the file watchers.

Issue is when one uses an editor (like vim), which instead of rewrite a file, deletes the file and then create a new one.
When a file is being deleted a watcher for the directory is being added.
But this thinking is flawed. Between a file is deleted and Studio register a file directory watcher it can happen
that a new file is being created. This causes to miss the reload-notification.
To solve this commit adds a directory watcher that always watches the directory and reloads the file if "lastModified" date has changed.
To do this properly it is necessary to track the file accross the "loadFile" function.
So the loadFile function is now split into two parts "loadFile(QString, ...)" and "loadFile(QFile, ...").
