### PR TITLE
Fixed Qt to QString (compilation errors)

### DIFF
--- a/studio/src/syntax.cpp
+++ b/studio/src/syntax.cpp
@@ -201,7 +201,7 @@ void Syntax::setKeywords(QString kws)
     QTextCharFormat kw_format;
     kw_format.setForeground(Color::blue);
 
-    for (auto k : kws.split(' ', Qt::SkipEmptyParts))
+    for (auto k : kws.split(' ', QString::SkipEmptyParts))
     {
         auto esc = QRegularExpression::escape(k);
         rules << Rule("(?<=[^\\w-]|^)" + esc + "(?=[^\\w-]|$)", kw_format);


### PR DESCRIPTION
Also, `QString::SkipEmptyParts` is obsolete
[https://doc.qt.io/qt-5/qstring-obsolete.html](url)