### PR TITLE
Support direct modeling in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The library is written in C++ and exposes a C API in `libfive.h`.
 It uses the Python and Guile bindings and allows for live-coding of solid models.
 The interface also includes direct modeling,
 where the user can push and pull on the model's surface
-to change variables in the script (direct modeling is Guile-only, for now).
+to change variables in the script.
 
 ## Other projects using `libfive`
 ### Language bindings

--- a/libfive/bind/python/libfive/runner.py
+++ b/libfive/bind/python/libfive/runner.py
@@ -44,7 +44,7 @@ class VarTransformer(ast.NodeTransformer):
             self._i += 1
         return node
 
-def run(s):
+def run(s, **env):
     ''' Evaluates a string, clause-by-clause.
 
         Returns a list of values from each expression in the string, or
@@ -52,7 +52,7 @@ def run(s):
     '''
     parsed = ast.parse(s)
     tagged = VarTransformer().generic_visit(parsed)
-    gs = {}
+    gs = {**env}
     out = []
     for p in tagged.body:
         if isinstance(p, ast.Expr):

--- a/libfive/bind/python/libfive/runner.py
+++ b/libfive/bind/python/libfive/runner.py
@@ -14,17 +14,28 @@ class VarTransformer(ast.NodeTransformer):
     def __init__(self):
         self._i = 0
 
+    def check_var(self, node):
+        if len(node.args) != 1 or node.keywords:
+            return "var() must take 1 argument"
+        if isinstance(node.args[0], ast.Constant):
+            if not isinstance(node.args[0].value, numbers.Number):
+                return "var() argument must be a number"
+            else:
+                pass # Numerical constant
+        elif isinstance(node.args[0], ast.UnaryOp):
+            if not isinstance(node.args[0].op, ast.USub):
+                return "var() argument must be a constant"
+            elif not isinstance(node.args[0].operand, ast.Constant):
+                return "var() argument must be a constant"
+            elif not isinstance(node.args[0].operand.value, numbers.Number):
+                return "var() argument must be a number"
+            else:
+                pass # Unary subtraction
+        else:
+            return "var() argument must be a constant"
+
     def visit_Call(self, node):
         if isinstance(node.func, ast.Name) and node.func.id == 'var':
-            # TODO: inject these errors into the script, so that they end
-            # up producing a reasonable backtrace.
-            if len(node.args) != 1 or node.keywords:
-                raise RuntimeError("var() must take 1 argument")
-            elif not isinstance(node.args[0], ast.Constant):
-                raise RuntimeError("var() must take a constant argument")
-            elif not isinstance(node.args[0].value, numbers.Number):
-                raise RuntimeError("var() argument must be a number")
-
             # We'll be injecting more arguments into the var() call, but don't
             # want to mess up tagged lines and columns, so we'll use a set of
             # dummy fields that indicate that the new arguments have size 0.
@@ -35,13 +46,21 @@ class VarTransformer(ast.NodeTransformer):
                 'end_col_offset': node.end_col_offset,
             }
 
-            # Each var gets a tag explaining where to find it in the text,
-            # and is deduplicated based on order in the AST.
-            node.args.append(ast.Constant(value=(
-                node.lineno, node.end_lineno,
-                node.col_offset, node.end_col_offset), **dummy))
+            # Patch the call to be var('error string') if the AST is invalid.
+            # This is checked by the var function and re-raised as a
+            # RuntimeError, rather than raising it here (which would produce
+            # a confusing traceback).
+            err = self.check_var(node)
+            if err:
+                node.args[0] = ast.Constant(value=err, **dummy)
+            else:
+                # Each var gets a tag explaining where to find it in the text,
+                # and is deduplicated based on order in the AST.
+                node.args.append(ast.Constant(value=(
+                    node.lineno, node.end_lineno,
+                    node.col_offset + 4, node.end_col_offset), **dummy))
             self._i += 1
-        return node
+        return self.generic_visit(node) # Recurse, e.g. to patch sphere(var(1))
 
 def run(s, **env):
     ''' Evaluates a string, clause-by-clause.

--- a/libfive/bind/python/libfive/runner.py
+++ b/libfive/bind/python/libfive/runner.py
@@ -51,6 +51,7 @@ def run(s, **env):
     '''
     parsed = ast.parse(s)
     tagged = VarTransformer().generic_visit(parsed)
+    print(ast.unparse(tagged))
     gs = {**env}
     out = []
     for p in tagged.body:

--- a/libfive/bind/python/libfive/runner.py
+++ b/libfive/bind/python/libfive/runner.py
@@ -8,6 +8,41 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 
 import ast
+import numbers
+
+class VarTransformer(ast.NodeTransformer):
+    def __init__(self):
+        self._i = 0
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Name) and node.func.id == 'var':
+            # TODO: inject these errors into the script, so that they end
+            # up producing a reasonable backtrace.
+            if len(node.args) != 1 or node.keywords:
+                raise RuntimeError("var() must take 1 argument")
+            elif not isinstance(node.args[0], ast.Constant):
+                raise RuntimeError("var() must take a constant argument")
+            elif not isinstance(node.args[0].value, numbers.Number):
+                raise RuntimeError("var() argument must be a number")
+
+            # We'll be injecting more arguments into the var() call, but don't
+            # want to mess up tagged lines and columns, so we'll use a set of
+            # dummy fields that indicate that the new arguments have size 0.
+            dummy = {
+                'lineno': node.end_lineno,
+                'end_lineno': node.end_lineno,
+                'col_offset': node.end_col_offset,
+                'end_col_offset': node.end_col_offset,
+            }
+
+            # Each var gets a unique ID based on order of appearance in the AST,
+            # plus a tag explaining where to find it in the text.
+            node.args.append(ast.Constant(value=self._i, **dummy))
+            node.args.append(ast.Constant(value=(
+                node.lineno, node.end_lineno,
+                node.col_offset, node.end_col_offset), **dummy))
+            self._i += 1
+        return node
 
 def run(s):
     ''' Evaluates a string, clause-by-clause.
@@ -16,10 +51,10 @@ def run(s):
         raises an error if something went wrong.
     '''
     parsed = ast.parse(s)
-    # TODO: hotpatch var(...) nodes
+    tagged = VarTransformer().generic_visit(parsed)
     gs = {}
     out = []
-    for p in parsed.body:
+    for p in tagged.body:
         if isinstance(p, ast.Expr):
             exp = ast.Expression(p.value)
             f = compile(exp, '<file>', 'eval')
@@ -32,4 +67,3 @@ def run(s):
             f = compile(mod, '<file>', 'exec')
             exec(f, gs)
     return out
-

--- a/libfive/bind/python/libfive/runner.py
+++ b/libfive/bind/python/libfive/runner.py
@@ -35,9 +35,8 @@ class VarTransformer(ast.NodeTransformer):
                 'end_col_offset': node.end_col_offset,
             }
 
-            # Each var gets a unique ID based on order of appearance in the AST,
-            # plus a tag explaining where to find it in the text.
-            node.args.append(ast.Constant(value=self._i, **dummy))
+            # Each var gets a tag explaining where to find it in the text,
+            # and is deduplicated based on order in the AST.
             node.args.append(ast.Constant(value=(
                 node.lineno, node.end_lineno,
                 node.col_offset, node.end_col_offset), **dummy))

--- a/libfive/bind/python/libfive/shape.py
+++ b/libfive/bind/python/libfive/shape.py
@@ -122,6 +122,9 @@ class Shape:
     def with_constant_vars(self):
         return Shape.new('const-var', self.ptr)
 
+    def lock(self):
+        return self.with_constant_vars()
+
     def optimized(self):
         return Shape(lib.libfive_tree_optimized(self.ptr));
 

--- a/studio/include/studio/python/interpreter.hpp
+++ b/studio/include/studio/python/interpreter.hpp
@@ -46,6 +46,7 @@ public slots:
 protected:
     PyObject* m_runFunc=NULL;
     PyObject* m_shapeClass=NULL;
+    PyObject* m_varFunc=NULL;
     PyThreadState* m_threadState=NULL;
     unsigned long m_workerThreadId=0;
 


### PR DESCRIPTION
This implements direct (push/pull) modeling in Python.

Shapes can be parameterized with free variables using the `var(...)` function.  Before evaluation, we walk the AST and patch these function calls with ID and textual location, so that we can edit the script to substitute in new values.

https://user-images.githubusercontent.com/745333/111542364-feab5080-8747-11eb-80a5-fc904122f278.mov

Luckily, the Scheme implementation was already pretty abstract, so I didn't need to make any changes on the push-pull-edit side, just needed to output the right things from the `Interpreter`.
