### PR TITLE
Mouse rotation sensitivity

### DIFF
--- a/studio/include/studio/camera.hpp
+++ b/studio/include/studio/camera.hpp
@@ -88,6 +88,7 @@ protected:
     QVector3D center={0,0,0};
     float pitch=128;
     float yaw=-59;
+    float rotationSensitivity=360;
 
     float perspective=0.25;
     Q_PROPERTY(float perspective MEMBER perspective NOTIFY changed)

--- a/studio/include/studio/camera.hpp
+++ b/studio/include/studio/camera.hpp
@@ -42,6 +42,14 @@ public:
     void toTurnY();
 
     /*
+     *  Sets the mouse rotation sensitivity of the viewport 
+     *  in degrees per windown size. (Angle rotated for 
+     *  distance dragged across the screen, relative to the 
+     *  size of the window)
+     */
+    void setRotationSensitivity(float sensitivity);
+
+    /*
      *  Triggers an animation to zoom to the given setting
      */
     void zoomTo(const QVector3D& min, const QVector3D& max);

--- a/studio/include/studio/view.hpp
+++ b/studio/include/studio/view.hpp
@@ -64,6 +64,9 @@ public slots:
     void toPerspective(bool=false)  { camera.toPerspective();   }
     void toTurnZ(bool=false) { camera.toTurnZ();  }
     void toTurnY(bool=false)  { camera.toTurnY();   }
+    void setLowRotSensitivity(bool=false)  { camera.setRotationSensitivity(240); }
+    void setMedRotSensitivity(bool=false)  { camera.setRotationSensitivity(360); }
+    void setHighRotSensitivity(bool=false) { camera.setRotationSensitivity(720); }
     void zoomTo(bool=false) { camera.zoomTo(settings.min, settings.max); }
 
     void toDCMeshing();

--- a/studio/src/camera.cpp
+++ b/studio/src/camera.cpp
@@ -69,8 +69,8 @@ QMatrix4x4 Camera::M() const
 
 void Camera::rotateIncremental(QPoint delta)
 {
-    pitch += delta.y();
-    yaw += delta.x();
+    pitch += rotationSensitivity*float(delta.y()/float(size.height()));
+    yaw += rotationSensitivity*float(delta.x()/float(size.width()));
 
     pitch = fmax(fmin(pitch, 180), 0);
     yaw = fmod(yaw, 360);

--- a/studio/src/camera.cpp
+++ b/studio/src/camera.cpp
@@ -141,6 +141,11 @@ void Camera::toTurnY()
     animateAxis(QQuaternion::fromDirection({0, 1, 0}, {0, 0, 1}));
 }
 
+void Camera::setRotationSensitivity(float sensitivity)
+{
+    rotationSensitivity = sensitivity;
+}
+
 void Camera::zoomTo(const QVector3D& min, const QVector3D& max)
 {
     QVector3D center_start = center;

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -204,6 +204,23 @@ Window::Window(Arguments args)
     connect(turn_y_up, &QAction::triggered, view, &View::toTurnY);
     view_menu->addMenu(rotation_menu);
 
+    auto sensitivity_low = new QAction("Low Sensitivity", nullptr);
+    auto sensitivity_medium = new QAction("Medium Sensitivity", nullptr);
+    auto sensitivity_high = new QAction("High Sensitivity", nullptr);
+    auto sensitivity_menu = new QMenu("Rotation Sensitivity");
+    sensitivity_menu->addAction(sensitivity_low);
+    sensitivity_menu->addAction(sensitivity_medium);
+    sensitivity_menu->addAction(sensitivity_high);
+    sensitivity_low->setCheckable(true);
+    sensitivity_medium->setCheckable(true);
+    sensitivity_medium->setChecked(true);
+    sensitivity_high->setCheckable(true);
+    auto sense_mode = new QActionGroup(sensitivity_menu);
+    sense_mode->addAction(sensitivity_low);
+    sense_mode->addAction(sensitivity_medium);
+    sense_mode->addAction(sensitivity_high);
+    view_menu->addMenu(sensitivity_menu);
+
     view_menu->addSeparator();
     auto zoom_to_action = new QAction("Zoom to bounds", nullptr);
     view_menu->addAction(zoom_to_action);

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -219,6 +219,9 @@ Window::Window(Arguments args)
     sense_mode->addAction(sensitivity_low);
     sense_mode->addAction(sensitivity_medium);
     sense_mode->addAction(sensitivity_high);
+    connect(sensitivity_low, &QAction::triggered, view, &View::setLowRotSensitivity);
+    connect(sensitivity_medium, &QAction::triggered, view, &View::setMedRotSensitivity);
+    connect(sensitivity_high, &QAction::triggered, view, &View::setHighRotSensitivity);
     view_menu->addMenu(sensitivity_menu);
 
     view_menu->addSeparator();


### PR DESCRIPTION
Changed the mouse rotation to be responsive to the size of the viewport. This is so that the rotation amount is more intuitive for the size of window/screen. Also toned down the default rotation speed a bit. This is easily controllable with the new Camera::rotationSensitivity variable.

Added a selection drop down to the view menu for selecting between low, medium, and high sensitivities.

A proper slider would be nice in the future for the user to fully customize their sensitivity, but it isn't as easy with the current drop down style settings menu.
