### PR TITLE
Improved shaders

### DIFF
--- a/studio/gl/basic.frag
+++ b/studio/gl/basic.frag
@@ -25,9 +25,24 @@ void main() {
         norm.z /= 8;
         norm = normalize(norm);
 
+        float shininess = 16.0;
+
         // Per-fragment shading
-        vec3 dpos = normalize(vec3(1.0, -1.0, 4.0) - frag_pos);
-        float brightness = dot(norm, dpos);
+
+        //Light positioning
+        vec3 light_pos = vec3(0.0, 0.0, 1.0);
+        
+        //Diffuse lighting
+        //z set to 3 to place the light further and get a more even diffuse lighting
+        vec3 dpos = normalize(light_pos + vec3(frag_pos.xy,3));
+        float diffuse = max(0.0, dot(norm, dpos));
+
+        //Specular lighting
+        vec3 spos = normalize(light_pos + vec3(frag_pos.xy,0));
+        float specular = pow(max(0.0, dot(norm, spos)), shininess);
+
+        //mix diffuse and specular
+        float brightness = mix(diffuse, specular, 0.5);
 
         fragColor = vec4(brightness, brightness, brightness, 1.0);
     }

--- a/studio/gl/basic.frag
+++ b/studio/gl/basic.frag
@@ -42,7 +42,7 @@ void main() {
         float specular = pow(max(0.0, dot(norm, spos)), shininess);
 
         //mix diffuse and specular
-        float brightness = mix(diffuse, specular, 0.5);
+        float brightness = mix(diffuse, specular, 0.5); //50% mix
 
         fragColor = vec4(brightness, brightness, brightness, 1.0);
     }

--- a/studio/gl/outline.frag
+++ b/studio/gl/outline.frag
@@ -1,0 +1,11 @@
+#version 150
+
+in vec3 frag_norm;
+in vec3 frag_pos;
+in vec4 frag_color;
+
+out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+}

--- a/studio/gl/outline.frag
+++ b/studio/gl/outline.frag
@@ -7,5 +7,6 @@ in vec4 frag_color;
 out vec4 fragColor;
 
 void main() {
+    //Render outline in black
     fragColor = vec4(0.0, 0.0, 0.0, 1.0);
 }

--- a/studio/gl/outline.geom
+++ b/studio/gl/outline.geom
@@ -15,12 +15,14 @@ vec3 normal(vec3 p1, vec3 p2, vec3 p3)
 
 void main()
 {
+    //Generate normal from triangle
     vec3 norm = normal(gl_in[0].gl_Position.xyz, gl_in[1].gl_Position.xyz, gl_in[2].gl_Position.xyz);
 
     //Offset to 'thicken' the object
     float offset = 0.05;
     norm = norm*offset;
 
+    //Apply to each vertex of the triangle
     gl_Position = M*(gl_in[0].gl_Position + vec4(norm,0));
     EmitVertex();
 

--- a/studio/gl/outline.geom
+++ b/studio/gl/outline.geom
@@ -1,0 +1,34 @@
+#version 150
+#extension GL_ARB_explicit_attrib_location : require
+
+layout (triangles) in;
+layout (triangle_strip, max_vertices = 3) out;
+
+uniform mat4 M;
+
+vec3 normal(vec3 p1, vec3 p2, vec3 p3)
+{
+   vec3 a = p2 - p1;
+   vec3 b = p3 - p1;
+   return normalize(cross(a, b));
+}
+
+void main()
+{
+    vec3 norm = normal(gl_in[0].gl_Position.xyz, gl_in[1].gl_Position.xyz, gl_in[2].gl_Position.xyz);
+
+    //Offset to 'thicken' the object
+    float offset = 0.05;
+    norm = norm*offset;
+
+    gl_Position = M*(gl_in[0].gl_Position + vec4(norm,0));
+    EmitVertex();
+
+    gl_Position = M*(gl_in[1].gl_Position + vec4(norm,0));
+    EmitVertex();
+
+    gl_Position = M*(gl_in[2].gl_Position + vec4(norm,0));
+    EmitVertex();
+    
+    EndPrimitive();
+}  

--- a/studio/gl/outline.vert
+++ b/studio/gl/outline.vert
@@ -1,0 +1,31 @@
+#version 150
+#extension GL_ARB_explicit_attrib_location : require
+
+layout(location=0) in vec3 vertex_position;
+layout(location=1) in vec3 vertex_color;
+
+uniform mat4 M;
+
+out vec4 frag_color;
+out vec3 base_pos;
+out vec3 frag_pos;
+out vec3 frag_norm;
+
+void main()
+{
+    // base_pos = vertex_position;
+
+    // gl_Position = M * vec4(vertex_position, 1.0f);
+    // gl_Position.w = max(0, gl_Position.w);
+
+    // frag_pos = gl_Position.xyz / gl_Position.w;
+    // frag_color = vec4(vertex_color, 1.0f);
+
+    // vec4 norm_pos = M * vec4(vertex_position + vertex_norm, 1.0f);
+    // frag_norm = (norm_pos.xyz / norm_pos.w) - frag_pos;
+    // frag_norm.z *= -8;
+    // frag_norm = normalize(frag_norm);
+
+
+    gl_Position = vec4(vertex_position, 1);
+}

--- a/studio/gl/outline.vert
+++ b/studio/gl/outline.vert
@@ -13,19 +13,7 @@ out vec3 frag_norm;
 
 void main()
 {
-    // base_pos = vertex_position;
-
-    // gl_Position = M * vec4(vertex_position, 1.0f);
-    // gl_Position.w = max(0, gl_Position.w);
-
-    // frag_pos = gl_Position.xyz / gl_Position.w;
-    // frag_color = vec4(vertex_color, 1.0f);
-
-    // vec4 norm_pos = M * vec4(vertex_position + vertex_norm, 1.0f);
-    // frag_norm = (norm_pos.xyz / norm_pos.w) - frag_pos;
-    // frag_norm.z *= -8;
-    // frag_norm = normalize(frag_norm);
-
-
+    //Simple pass-through
+    //transformation matrix is handled in the geometry shader
     gl_Position = vec4(vertex_position, 1);
 }

--- a/studio/include/studio/shader.hpp
+++ b/studio/include/studio/shader.hpp
@@ -27,6 +27,7 @@ namespace Shader
     void initializeGL();
 
     extern QOpenGLShaderProgram* basic;
+    extern QOpenGLShaderProgram* outline;
 
     extern QOpenGLShaderProgram* busy;
     extern QOpenGLShaderProgram* line;

--- a/studio/resources.qrc
+++ b/studio/resources.qrc
@@ -2,6 +2,9 @@
     <qresource prefix="/">
         <file>gl/basic.vert</file>
         <file>gl/basic.frag</file>
+        <file>gl/outline.vert</file>
+        <file>gl/outline.frag</file>
+        <file>gl/outline.geom</file>
         <file>gl/busy.frag</file>
         <file>gl/line.vert</file>
 

--- a/studio/src/shader.cpp
+++ b/studio/src/shader.cpp
@@ -22,23 +22,30 @@ namespace Studio {
 namespace Shader {
 
 QOpenGLShaderProgram* basic;
+QOpenGLShaderProgram* outline;
 QOpenGLShaderProgram* point;
 QOpenGLShaderProgram* busy;
 QOpenGLShaderProgram* line;
 
 void initializeGL()
 {
-    auto build = [](QString vert, QString frag) {
+    auto build = [](QString vert, QString frag, QString geom="") {
         auto s = new QOpenGLShaderProgram;
         s->addShaderFromSourceFile(
                 QOpenGLShader::Vertex, ":/gl/" + vert + ".vert");
         s->addShaderFromSourceFile(
                 QOpenGLShader::Fragment, ":/gl/" + frag + ".frag");
+        if (geom.length() != 0)
+        {
+            s->addShaderFromSourceFile(
+                    QOpenGLShader::Geometry, ":/gl/" + geom + ".geom");
+        }
         s->link();
         return s;
     };
 
     basic = build("basic", "basic");
+    outline = build("outline", "outline", "outline");
     busy = build("basic", "busy");
     line = build("line", "basic");
 }

--- a/studio/src/shader.cpp
+++ b/studio/src/shader.cpp
@@ -35,6 +35,7 @@ void initializeGL()
                 QOpenGLShader::Vertex, ":/gl/" + vert + ".vert");
         s->addShaderFromSourceFile(
                 QOpenGLShader::Fragment, ":/gl/" + frag + ".frag");
+        //Only use geometry shader if name is specified
         if (geom.length() != 0)
         {
             s->addShaderFromSourceFile(

--- a/studio/src/shape.cpp
+++ b/studio/src/shape.cpp
@@ -179,6 +179,7 @@ void Shape::draw(const QMatrix4x4& M)
     {
         auto s = (grabbed || hover) ? 1 : 0.9;
 
+        //Draw Shape
         Shader::basic->bind();
         glUniform4f(Shader::basic->uniformLocation("color_mul"),
                     0.96 * s, 0.75 * s, 0.63 * s, 1.0f);
@@ -191,6 +192,19 @@ void Shape::draw(const QMatrix4x4& M)
         glDrawElements(GL_TRIANGLES, mesh->branes.size() * 3, GL_UNSIGNED_INT, NULL);
         vao.release();
         Shader::basic->release();
+
+
+        //Draw Outline
+        Shader::outline->bind();
+        glUniformMatrix4fv(Shader::outline->uniformLocation("M"),
+                           1, GL_FALSE, M.data());
+        vao.bind();
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_FRONT); //Cull front faces so only outline is drawn
+        glDrawElements(GL_TRIANGLES, mesh->branes.size() * 3, GL_UNSIGNED_INT, NULL);
+        glDisable(GL_CULL_FACE);
+        vao.release();
+        Shader::outline->release();
     }
 }
 


### PR DESCRIPTION
Summary:
- Added specular shading to objects.
- Added outlines to objects.

I found it a bit difficult to see the shape of some objects, especially when large flat surfaces are involved. This helps break it up and make it easier to see the edges of your object.

The outline shader works by offsetting each triangle a small distance in the direction of its normal. (This can leave gaps if the offset is too large but it shouldn't be noticeable a the current setting.) This is then rendered with the front faces culled so only the faces behind and around the sides of the object are drawn. This gives the effect of an outline.

This could definitely be improved in the future but I figured this would be a good start.