### PR TITLE
Save application settings

### DIFF
--- a/studio/include/studio/view.hpp
+++ b/studio/include/studio/view.hpp
@@ -60,16 +60,16 @@ public slots:
     void showAxes(bool a);
     void showBBox(bool b);
 
-    void toOrthographic(bool=false) { camera.toOrthographic();  }
-    void toPerspective(bool=false)  { camera.toPerspective();   }
-    void toTurnZ(bool=false) { camera.toTurnZ();  }
-    void toTurnY(bool=false)  { camera.toTurnY();   }
-    void setLowRotSensitivity(bool=false)  { camera.setRotationSensitivity(240); }
-    void setMedRotSensitivity(bool=false)  { camera.setRotationSensitivity(360); }
-    void setHighRotSensitivity(bool=false) { camera.setRotationSensitivity(720); }
-    void setZoomCursorCentric(bool=false) { zoom_cursor_centric = true; }
-    void setZoomSceneCentric(bool=false) { zoom_cursor_centric = false; }
-    void zoomTo(bool=false) { camera.zoomTo(settings.min, settings.max); }
+    void toOrthographic() { camera.toOrthographic();  }
+    void toPerspective()  { camera.toPerspective();   }
+    void toTurnZ() { camera.toTurnZ();  }
+    void toTurnY()  { camera.toTurnY();   }
+    void setLowRotSensitivity()  { camera.setRotationSensitivity(240); }
+    void setMedRotSensitivity()  { camera.setRotationSensitivity(360); }
+    void setHighRotSensitivity() { camera.setRotationSensitivity(720); }
+    void setZoomCursorCentric() { zoom_cursor_centric = true; }
+    void setZoomSceneCentric() { zoom_cursor_centric = false; }
+    void zoomTo() { camera.zoomTo(settings.min, settings.max); }
 
     void toDCMeshing();
     void toIsoMeshing();

--- a/studio/include/studio/view.hpp
+++ b/studio/include/studio/view.hpp
@@ -67,6 +67,8 @@ public slots:
     void setLowRotSensitivity(bool=false)  { camera.setRotationSensitivity(240); }
     void setMedRotSensitivity(bool=false)  { camera.setRotationSensitivity(360); }
     void setHighRotSensitivity(bool=false) { camera.setRotationSensitivity(720); }
+    void setZoomCursorCentric(bool=false) { zoom_cursor_centric = true; }
+    void setZoomSceneCentric(bool=false) { zoom_cursor_centric = false; }
     void zoomTo(bool=false) { camera.zoomTo(settings.min, settings.max); }
 
     void toDCMeshing();
@@ -167,6 +169,8 @@ protected:
 
     bool show_axes=true;
     bool show_bbox=false;
+
+    bool zoom_cursor_centric = true;
 
     /*  Framebuffer to render pick data  */
     QScopedPointer<QOpenGLFramebufferObject> pick_fbo;

--- a/studio/include/studio/window.hpp
+++ b/studio/include/studio/window.hpp
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <QMainWindow>
 #include <QMessageBox>
 #include <QFileSystemWatcher>
+#include <QSettings>
 
 #include "studio/args.hpp"
 #include "studio/language.hpp"
@@ -107,5 +108,8 @@ protected:
     Editor* editor;
     View* view;
     bool closing=false;
+
+    /* Used to (re)store the state of the application */
+    QSettings settings;
 };
 }   // namespace Studio

--- a/studio/src/view.cpp
+++ b/studio/src/view.cpp
@@ -503,7 +503,8 @@ void View::wheelEvent(QWheelEvent *event)
 {
     QOpenGLWidget::wheelEvent(event);
     event->accept();
-    camera.zoomIncremental(event->angleDelta().y(), mouse.pos);
+    const QPoint& center = zoom_cursor_centric ? mouse.pos : rect().center();
+    camera.zoomIncremental(event->angleDelta().y(), center);
     update();
     pick_timer.start();
 }

--- a/studio/src/window.cpp
+++ b/studio/src/window.cpp
@@ -224,6 +224,21 @@ Window::Window(Arguments args)
     connect(sensitivity_high, &QAction::triggered, view, &View::setHighRotSensitivity);
     view_menu->addMenu(sensitivity_menu);
 
+    auto cursor_centric = new QAction("Cursor", nullptr);
+    auto scene_centric = new QAction("Scene", nullptr);
+    auto zoom_menu = new QMenu("Zoom center");
+    zoom_menu->addAction(cursor_centric);
+    zoom_menu->addAction(scene_centric);
+    cursor_centric->setCheckable(true);
+    scene_centric->setCheckable(true);
+    cursor_centric->setChecked(true);
+    auto zoom_mode = new QActionGroup(zoom_menu);
+    zoom_mode->addAction(cursor_centric);
+    zoom_mode->addAction(scene_centric);
+    connect(cursor_centric, &QAction::triggered, view, &View::setZoomCursorCentric);
+    connect(scene_centric, &QAction::triggered, view, &View::setZoomSceneCentric);
+    view_menu->addMenu(zoom_menu);
+
     view_menu->addSeparator();
     auto zoom_to_action = new QAction("Zoom to bounds", nullptr);
     view_menu->addAction(zoom_to_action);


### PR DESCRIPTION
I've (presumptuously) based the PR on the other one since they're related but I can change that.

The settings keys are in kebab case as was `first-run`. I didn't bother with using string constants (for key and value) since they're used in local contexts where it's easy to check that they're correct.

The concerned signals are changed from `triggered` to `toggled` since this is how we set the default value. One unfortunate consequence is that animation are played based on the default value. Maybe we can disable animations during construction?

I also noticed that the default language is controlled by a commandline flag, but maybe a setting can be added such that CLI flag > setting value > default value?