### PR TITLE
Python bindings: add calls to render mesh

### DIFF
--- a/libfive/bind/python/libfive/ffi.py
+++ b/libfive/bind/python/libfive/ffi.py
@@ -64,6 +64,17 @@ class libfive_vec3_t(ctypes.Structure):
 
 libfive_tree = ctypes.c_void_p
 
+class libfive_tri_t(ctypes.Structure):
+    _fields_ = [("a", ctypes.c_uint32),
+                ("b", ctypes.c_uint32),
+                ("c", ctypes.c_uint32)]
+
+class libfive_mesh_t(ctypes.Structure):
+    _fields_ = [("verts", ctypes.POINTER(libfive_vec3_t)),
+                ("tris",  ctypes.POINTER(libfive_tri_t)),
+                ("tri_count", ctypes.c_uint32),
+                ("vert_count", ctypes.c_uint32)]
+
 ################################################################################
 
 # Types used in the libfive stdlib
@@ -138,3 +149,8 @@ lib.libfive_tree_eval_d.restype = libfive_vec3_t
 
 lib.libfive_tree_optimized.argtypes = [libfive_tree]
 lib.libfive_tree_optimized.restype = libfive_tree
+
+lib.libfive_tree_render_mesh.argtypes = [libfive_tree, libfive_region_t, ctypes.c_float]
+lib.libfive_tree_render_mesh.restype = ctypes.POINTER(libfive_mesh_t)
+
+lib.libfive_mesh_delete.argtypes = [ctypes.POINTER(libfive_mesh_t)]

--- a/libfive/bind/python/libfive/shape.py
+++ b/libfive/bind/python/libfive/shape.py
@@ -242,6 +242,32 @@ class Shape:
         lib.libfive_tree_save_mesh(self.ptr, region, resolution,
                                    filename.encode('ascii'))
 
+    def get_mesh(self, xyz_min=(-10,-10,-10), xyz_max=(10,10,10),
+                 resolution=10):
+        ''' Converts this Shape into a mesh, and returns that mesh in
+            the form of a face-vertex mesh.
+
+        Options are the same as in save_stl().
+
+        Returns:
+        verts - List of (x, y, z) vertices
+        tris - List of (a, b, c) indices into verts
+        '''
+        region = libfive_region_t(*[libfive_interval_t(a, b) for a, b
+                                    in zip(xyz_min, xyz_max)])
+        mesh_p = lib.libfive_tree_render_mesh(self.ptr, region, resolution)
+        mesh = mesh_p[0]
+        tris = []
+        for i in range(mesh.tri_count):
+            f = mesh.tris[i]
+            tris.append((f.a, f.b, f.c))
+        verts = []
+        for i in range(mesh.vert_count):
+            v = mesh.verts[i]
+            verts.append((v.x, v.y, v.z))
+        lib.libfive_mesh_delete(mesh_p)
+        return verts, tris
+
     def show(self, xyz_min=(-10,-10,-10), xyz_max=(10,10,10), resolution=10):
         with open('.out.stl','wb') as f:
             self.save_stl(f.name, xyz_min, xyz_max, resolution)


### PR DESCRIPTION
I was experimenting with getting to mesh data via Python bindings, needed to add a few types in the process, and thought this might be useful for other people.