### PR TITLE
Add path to installed libraries to ffi.py

### DIFF
--- a/libfive/bind/python/CMakeLists.txt
+++ b/libfive/bind/python/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(SRCS
     libfive/__init__.py
-    libfive/ffi.py
     libfive/runner.py
     libfive/shape.py
 
@@ -9,6 +8,10 @@ set(SRCS
     libfive/stdlib/shapes.py
     libfive/stdlib/transforms.py
     libfive/stdlib/text.py
+)
+
+set(FFI
+    libfive/ffi.py
 )
 
 set(OUTS "")
@@ -24,6 +27,8 @@ foreach(SRC ${SRCS})
 endforeach(SRC)
 
 add_custom_target(libfive-python ALL DEPENDS ${OUTS})
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${FFI}  "${CMAKE_CURRENT_BINARY_DIR}/${FFI}")
 
 ################################################################################
 

--- a/libfive/bind/python/libfive/ffi.py
+++ b/libfive/bind/python/libfive/ffi.py
@@ -27,13 +27,16 @@ def try_link(folder, name):
 def paths_for(folder):
     # In most cases, we are running from the top-level build folder, which
     # contains libfive/{folder}/{library}.{suffix}
-    paths = [os.path.join('libfive', folder),
-             os.path.join('${CMAKE_INSTALL_PREFIX}', 'lib')]
+    paths = [os.path.join('libfive', folder)]
 
     # On Windows, we may be running from the studio subfolder if Studio.exe
     # was double-checked, which puts the build directory up one level.
     if sys.platform == 'win32':
         paths.append(os.path.join('..', 'libfive', folder))
+
+    # On linux, the libraries are installed to CMAKE_INSTALL_PREFIX/lib.
+    if sys.platform == "linux" or sys.platform == "linux2":
+        paths.append(os.path.join('${CMAKE_INSTALL_PREFIX}', 'lib'))
     paths.append("")
     framework_dir = os.environ.get('LIBFIVE_FRAMEWORK_DIR')
     if framework_dir:

--- a/libfive/bind/python/libfive/ffi.py
+++ b/libfive/bind/python/libfive/ffi.py
@@ -27,7 +27,8 @@ def try_link(folder, name):
 def paths_for(folder):
     # In most cases, we are running from the top-level build folder, which
     # contains libfive/{folder}/{library}.{suffix}
-    paths = [os.path.join('libfive', folder)]
+    paths = [os.path.join('libfive', folder),
+             os.path.join('${CMAKE_INSTALL_PREFIX}', 'lib')]
 
     # On Windows, we may be running from the studio subfolder if Studio.exe
     # was double-checked, which puts the build directory up one level.


### PR DESCRIPTION
By default, `libfive/bin/python/ffi.py` searches for the `libfive` and `libfive-stdlib` libraries in the relative paths `.` and `libfive`; as a consequence, `from libfive import stdlib` fails if the script is not run in the build directory.  

Cmake installs the libraries to `${CMAKE_INSTALL_PREFIX}/lib`.  I added that path to the `paths` variable in `ffi.py`, using the cmake `configure_file` function to replace the `${CMAKE_INSTALL_PREFIX}` variable with the correct path.  As a consequence, `ffi.py` is now copied into the build directory by cmake, rather than deferring to make.  I don't know if that approach is acceptable here.  Additionally, I've only been able to test this on linux (Ubuntu 20.04), so I put the changes to `ffi.py` behind a system check.

This change means, after running `make install`, the python bindings can be used from anywhere on the system.