### PR TITLE
Eigen 3.4 aligned alloc workaround

### DIFF
--- a/libfive/include/libfive/eval/eval_array.hpp
+++ b/libfive/include/libfive/eval/eval_array.hpp
@@ -124,6 +124,12 @@ public:
     /*  Make an aligned new operator, as this class has Eigen structs
      *  inside of it (which are aligned for SSE) */
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<ArrayEvaluator>, size);
+    }
+    #endif
 };
 
 }   // namespace libfive

--- a/libfive/include/libfive/oracle/oracle_storage.hpp
+++ b/libfive/include/libfive/oracle/oracle_storage.hpp
@@ -55,6 +55,12 @@ public:
      *  inside of it (which are aligned for SSE) */
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<OracleStorage>, size);
+    }
+    #endif
+
 protected:
     /* Local storage for set(Vector3f) */
     Eigen::Array<float, 3, N> points;

--- a/libfive/include/libfive/render/brep/dc/dc_tree.hpp
+++ b/libfive/include/libfive/render/brep/dc/dc_tree.hpp
@@ -86,6 +86,16 @@ struct DCLeaf
     double BtB;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<DCLeaf>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
 };
 
 template <unsigned N>
@@ -183,6 +193,16 @@ public:
 
     /*  Boilerplate for an object that contains an Eigen struct  */
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<DCTree>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
 
     /*  Helper typedef for N-dimensional column vector */
     typedef Eigen::Matrix<double, N, 1> Vec;

--- a/libfive/include/libfive/render/brep/dc/intersection.hpp
+++ b/libfive/include/libfive/render/brep/dc/intersection.hpp
@@ -95,6 +95,16 @@ struct Intersection {
     double BtB;
     mutable int8_t rank=-1;
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<Intersection>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
 };
 
 }   // namespace libfive

--- a/libfive/include/libfive/render/brep/hybrid/hybrid_tree.hpp
+++ b/libfive/include/libfive/render/brep/hybrid/hybrid_tree.hpp
@@ -81,6 +81,16 @@ struct HybridLeaf
     Tape::Handle tape;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<HybridLeaf>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
 };
 
 template <unsigned N>
@@ -173,6 +183,16 @@ public:
 
     /*  Boilerplate for an object that contains an Eigen struct  */
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<HybridTree>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
 
     /*
      *  Releases this tree and any leaf objects to the given object pool

--- a/libfive/include/libfive/render/brep/region.hpp
+++ b/libfive/include/libfive/render/brep/region.hpp
@@ -264,6 +264,12 @@ public:
 
     /*  Boilerplate for an object that contains an Eigen struct  */
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<Region>, size);
+    }
+    #endif
 };
 
 }   // namespace libfive

--- a/libfive/include/libfive/render/brep/simplex/qef.hpp
+++ b/libfive/include/libfive/render/brep/simplex/qef.hpp
@@ -611,6 +611,16 @@ protected:
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<QEF>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
+
     friend class QEF<0>;
     friend class QEF<1>;
     friend class QEF<2>;

--- a/libfive/include/libfive/render/brep/simplex/simplex_tree.hpp
+++ b/libfive/include/libfive/render/brep/simplex/simplex_tree.hpp
@@ -59,6 +59,16 @@ struct SimplexLeafSubspace {
     std::atomic<uint32_t> refcount;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<SimplexLeafSubspace>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
 };
 
 template <unsigned N>
@@ -185,6 +195,16 @@ public:
 
     /*  Boilerplate for an object that contains an Eigen struct  */
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    #if EIGEN_MAJOR_VERSION == 4
+    void *operator new[](std::size_t size) {
+        return std::aligned_alloc(std::alignment_of_v<SimplexTree>, size);
+    }
+
+    void operator delete[](void* ptr) {
+        ::operator delete[](ptr);
+    }
+    #endif
 
     /*  Helper typedef for N-dimensional column vector */
     typedef Eigen::Matrix<double, N, 1> Vec;


### PR DESCRIPTION
eigen 3.4 nops the new operator macro but they forgot that aligned new has a different signature than non-aligned.
This also takes into account that we *need* to align our allocations, as this is not done by the default new.

This fixes #462 and #464.