### PR TITLE
Check if PYTHON_SITE_PACKAGES_DIR has been defined by the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ to update the system-wide installation of the executable and libraries.
 [`Studio.desktop`](https://github.com/libfive/libfive/blob/master/studio/deploy/linux/Studio.desktop)
 may be used to put a shortcut on your desktop.
 
+If you don't want the python bindings installed under /usr/lib, you
+can specify the install directory using the cmake variable
+PYTHON_SITE_PACKAGES_DIR, e.g.:
+```
+cmake -DPYTHON_SITE_PACKAGES_DIR=/usr/local/lib/python3.9/dist-packages .
+```
+
 Ubuntu releases before 20.04 are not officially supported;
 if you insist,
 there are hints [here](https://github.com/libfive/libfive/blob/b4e0e0bbf8c740a313754062a205a98ac336a19c/README.md#before-2004)

--- a/libfive/bind/python/CMakeLists.txt
+++ b/libfive/bind/python/CMakeLists.txt
@@ -28,10 +28,12 @@ add_custom_target(libfive-python ALL DEPENDS ${OUTS})
 ################################################################################
 
 if(UNIX)
-    # Find the site-packages directory
-    execute_process(
-        COMMAND ${Python3_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(), end='')"
-        OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_DIR)
+    if (NOT DEFINED PYTHON_SITE_PACKAGES_DIR)
+        # Find the site-packages directory
+	execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(), end='')"
+            OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_DIR)
+    endif()
 
     # Install all Python files into that directory
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libfive


### PR DESCRIPTION
Check if PYTHON_SITE_PACKAGES_DIR has been defined by the user before
asking Python for the system package library destination such that the
install destination for the Python bindings can be specified using,
e.g.

  cmake -DPYTHON_SITE_PACKAGES_DIR=/usr/local/lib/python3.9/dist-packages .