### PR TITLE
Fix std::exchange dependency issue

### DIFF
--- a/libfive/include/libfive/tree/tree.hpp
+++ b/libfive/include/libfive/tree/tree.hpp
@@ -12,6 +12,7 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <memory>
 #include <functional>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 


### PR DESCRIPTION
std::exchange now in scope with `#include <utility>`