### PR TITLE
Add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vcpkg
 .DS_Store
 __pycache__
 *.pyc
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, mkDerivation
+, wrapQtAppsHook
+, cmake
+, ninja
+, pkg-config
+, eigen
+, zlib
+, libpng
+, boost
+, stdenv
+, guile_3_0
+, version
+}:
+
+mkDerivation {
+  pname = "libfive-studio";
+  inherit version;
+
+  src = ./.;
+
+  nativeBuildInputs = [ wrapQtAppsHook cmake ninja pkg-config ];
+  buildInputs = [ eigen zlib libpng boost guile_3_0 ];
+
+  preConfigure = ''
+    substituteInPlace studio/src/guile/interpreter.cpp \
+      --replace "qputenv(\"GUILE_LOAD_COMPILED_PATH\", \"libfive/bind/guile\");" \
+                "qputenv(\"GUILE_LOAD_COMPILED_PATH\", \"libfive/bind/guile:$out/lib/guile/3.0/ccache\");"
+
+    substituteInPlace libfive/bind/guile/CMakeLists.txt \
+      --replace "LIBFIVE_FRAMEWORK_DIR=$<TARGET_FILE_DIR:libfive>" \
+                "LIBFIVE_FRAMEWORK_DIR=$out/lib" \
+      --replace "LIBFIVE_STDLIB_DIR=$<TARGET_FILE_DIR:libfive-stdlib>" \
+                "LIBFIVE_STDLIB_DIR=$out/lib"
+
+    export XDG_CACHE_HOME=$(mktemp -d)/.cache
+  '';
+  cmakeFlags = [
+    "-DBUILD_PYTHON_BINDINGS=0"
+    "-DGUILE_CCACHE_DIR=${placeholder "out"}/lib/guile/3.0/ccache"
+  ];
+
+  postInstall =
+    if stdenv.isDarwin then ''
+      # No rules to install the mac app, so do it manually.
+      mkdir -p $out/Applications
+      cp -r studio/Studio.app $out/Applications/Studio.app
+
+      install_name_tool \
+        -change libfive.dylib $out/lib/libfive.dylib \
+        -change libfive-guile.dylib $out/lib/libfive-guile.dylib \
+        $out/Applications/Studio.app/Contents/MacOS/Studio
+    '' else ''
+      # Link "Studio" binary to "libfive-studio" to be more obvious:
+      ln -s "$out/bin/Studio" "$out/bin/libfive-studio"
+    '';
+
+  meta = with lib; {
+    description = "Infrastructure for solid modeling with F-Reps in C, C++, and Guile";
+    homepage = "https://libfive.com/";
+    license = with licenses; [ mpl20 gpl2Plus ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1664432844,
+        "narHash": "sha256-/7YydlQfYeSN//5Q/nceSDeeBa5ZuO5c8wv9IULbOPg=",
+        "path": "/nix/store/v9pyldw4mn8w9qszygk9xb31ak0dgbkr-source",
+        "rev": "c4d0026e7346ad2006c2ba730d5a712c18195aab",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "A flake providing libfive, a framework for solid modeling using functional representations.";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+
+      sourceInfo =
+        if self.sourceInfo ? rev
+        then self.sourceInfo // {
+          # Tag would have to be set manually for stable releases flake
+          # because there's currently no way to get the tag via the interface.
+          # tag = v1.0.0;
+        }
+        else (throw "Can't get revision because the git tree is dirty");
+
+      version =
+        if sourceInfo ? tag
+        then sourceInfo.tag
+        else with sourceInfo; builtins.substring 0 8 lastModifiedDate + "-" + shortRev;
+
+      withPkgs = f: flake-utils.lib.eachDefaultSystem (system: f (import nixpkgs {
+        inherit system;
+      }));
+
+    in
+
+    withPkgs (pkgs:
+      let
+        libfive-studio = pkgs.libsForQt5.callPackage ./default.nix {
+          inherit version;
+        };
+      in
+      {
+
+        packages.default = libfive-studio;
+        apps.default = { type = "app"; program = "${libfive-studio}/bin/Studio"; };
+
+      });
+}


### PR DESCRIPTION
This flake includes an updated version of the (broken and outdated) [nixpkgs derivation](https://github.com/NixOS/nixpkgs/blob/350fd0044447ae8712392c6b212a18bdf2433e71/pkgs/development/libraries/libfive/default.nix). I tried splitting it into three packages (the libfive library, the guile bindings and the studio application) with a clear package dependency chain (to enable caching and avoid redundant rebuilds), but I was unable to untangle the build process and so I'm only including the full studio derivation.

I haven't attempted building or packaging the python bindings, as those weren't part of the derivation I based this on and I wasn't personally looking to use them.