### PR TITLE
A couple small bug fixes

### DIFF
--- a/libfive/bind/guile/libfive/kernel.scm
+++ b/libfive/bind/guile/libfive/kernel.scm
@@ -193,13 +193,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     (libfive-tree-eval-f (shape->ptr a) (vec3->ffi pt)))
 
 (define-method (shape-eval (a <shape>) (lower <vec3>) (upper <vec3>))
-    (apply cons
-      (parse-c-struct
-        (libfive-tree-eval-i (shape->ptr a)
-                 (libfive-region (libfive-interval (.x lower) (.x upper))
-                          (libfive-interval (.y lower) (.y upper))
-                          (libfive-interval (.z lower) (.z upper))))
-        (list float float))))
+  (apply cons
+         (parse-c-struct
+          (libfive-tree-eval-i (shape->ptr a)
+                               (libfive-region (list (.x lower) (.x upper))
+                                               (list (.y lower) (.y upper))
+                                               (list (.z lower) (.z upper))))
+          (list float float))))
 
 (define-method (shape-derivs (a <shape>) (pt <vec3>))
     (ffi->vec3 (libfive-tree-eval-d (shape->ptr a) (vec3->ffi pt))))

--- a/libfive/bind/guile/libfive/kernel.scm
+++ b/libfive/bind/guile/libfive/kernel.scm
@@ -308,6 +308,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     define-shape
     remap-shape
     make-var
+    shape?
     shape->string
     shape-eval
     shape-derivs

--- a/libfive/bind/guile/libfive/stdlib/text.scm
+++ b/libfive/bind/guile/libfive/stdlib/text.scm
@@ -18,6 +18,6 @@ It was last generated on 2022-02-09 19:39:26 by user bramp
   Returns the given text, rendered in a custom f-rep font
   (with a character height of 1)"
   (ptr->shape (ffi_text
-    (string->pointer txt)
+    (string->pointer txt "latin1")
     (vec2->tvec2 pos))))
 (export text)

--- a/libfive/bind/python/libfive/stdlib/text.py
+++ b/libfive/bind/python/libfive/stdlib/text.py
@@ -20,7 +20,7 @@ def text(txt, pos=(0, 0)):
     """ Returns the given text, rendered in a custom f-rep font
         (with a character height of 1)
     """
-    args = [txt.encode('utf-8'), list([Shape.wrap(i) for i in pos])]
+    args = [txt.encode('latin1'), list([Shape.wrap(i) for i in pos])]
     return Shape(stdlib.text(
         args[0],
         tvec2(*[a.ptr for a in args[1]])))

--- a/libfive/stdlib/gen_py.py
+++ b/libfive/stdlib/gen_py.py
@@ -34,7 +34,7 @@ def arg_wrap(a):
     elif a.type in ['float', 'int']:
         return a.name
     elif a.type == 'const char*':
-        return "{}.encode('utf-8')".format(a.name)
+        return "{}.encode('latin1')".format(a.name)
     elif a.type == 'tvec2':
         return "list([Shape.wrap(i) for i in {}])".format(a.name)
     elif a.type == 'tvec3':


### PR DESCRIPTION
Hello!

Just got a couple small bug fixes here.

I think it makes sense to add `shape?` to the available bindings.

The typo is pretty obviously wrong.

As for the `shape-eval` error, it is a little odd.  In `shape-save-mesh` we construct a `libfive-region` using lists instead of `libfive-interval`s so I have some confidence in my fix.