### PR TITLE
Add single-threaded version of libfive_tree_render_mesh

### DIFF
--- a/libfive/include/libfive.h
+++ b/libfive/include/libfive.h
@@ -356,6 +356,12 @@ void libfive_tree_save_slice(libfive_tree tree, libfive_region2 R,
 libfive_mesh* libfive_tree_render_mesh(libfive_tree tree,
                                        libfive_region3 R, float res);
 /*
+ * Same as libfive_tree_render_mesh, but forces single-threaded meshing to
+ * play nicely with FFI.
+ */
+libfive_mesh* libfive_tree_render_mesh_st(libfive_tree tree,
+                                       libfive_region3 R, float res);
+/*
  *  Renders to an alternate mesh format, see description of
  *  libfive_mesh_coords above.  The returned struct must be freed with
  *  libfive_mesh_coords_delete.

--- a/libfive/src/libfive.cpp
+++ b/libfive/src/libfive.cpp
@@ -303,12 +303,11 @@ void libfive_tree_save_slice(libfive_tree tree, libfive_region2 R, float z, floa
     cs->saveSVG(f);
 }
 
-libfive_mesh* libfive_tree_render_mesh(libfive_tree tree, libfive_region3 R, float res)
+libfive_mesh* libfive_tree_render_mesh_(libfive_tree tree, libfive_region3 R,
+                                        const BRepSettings& settings)
 {
     Region<3> region({R.X.lower, R.Y.lower, R.Z.lower},
                      {R.X.upper, R.Y.upper, R.Z.upper});
-    BRepSettings settings;
-    settings.min_feature = 1/res;
     auto ms = Mesh::render(Tree(tree), region, settings);
     if (ms.get() == nullptr)
     {
@@ -339,6 +338,19 @@ libfive_mesh* libfive_tree_render_mesh(libfive_tree tree, libfive_region3 R, flo
     return out;
 }
 
+libfive_mesh* libfive_tree_render_mesh(libfive_tree tree, libfive_region3 R, float res) {
+  BRepSettings settings;
+  settings.min_feature = 1/res;
+  return libfive_tree_render_mesh_(tree, R, settings);
+}
+
+libfive_mesh* libfive_tree_render_mesh_st(libfive_tree tree, libfive_region3 R, float res) {
+  BRepSettings settings;
+  settings.min_feature = 1/res;
+  settings.workers = 1;
+  return libfive_tree_render_mesh_(tree, R, settings);
+}
+ 
 libfive_mesh_coords* libfive_tree_render_mesh_coords(libfive_tree tree,
                                                      libfive_region3 R,
                                                      float res)


### PR DESCRIPTION
Tested and confirmed only hits 1 core when using `*_st` variant