### PR TITLE
Fix for gcc15.1

### DIFF
--- a/libfive/include/libfive/tree/tree.hpp
+++ b/libfive/include/libfive/tree/tree.hpp
@@ -8,6 +8,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this file,
 You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #pragma once
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <functional>

--- a/libfive/src/render/brep/vol/vol_tree.cpp
+++ b/libfive/src/render/brep/vol/vol_tree.cpp
@@ -30,7 +30,7 @@ VolTree::VolTree()
 
 std::unique_ptr<VolTree> VolTree::empty()
 {
-    std::unique_ptr<VolTree> t(new VolTree);
+    std::unique_ptr<VolTree> t = std::make_unique<VolTree>();
     t->type = Interval::EMPTY;
     return t;
 }


### PR DESCRIPTION
Adds a missing include to work with gcc15.1.


otherwise error message reads:
```bash
In file included from /home/gene/Coding/libfive/libfive/src/../include/libfive/eval/base.hpp:14,                  
                 from /home/gene/Coding/libfive/libfive/src/eval/base.cpp:12:                                                                                  
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:217:5: error: ‘uint32_t’ does not name a type
  217 |     uint32_t flags;                                                                                                                                    
      |     ^~~~~~~~                                                                                                                                           
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:21:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by add
ing ‘#include <cstdint>’                                                                                                                                       
   20 | #include "libfive/tree/operations.hpp"                                                                                                                 
  +++ |+#include <cstdint>                                                                                                                                     
   21 |                                                                                                                                                        
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:220:21: error: ‘uint32_t’ has not been declared
  220 |     Tree with_flags(uint32_t extra_flags) const;                                                                                                       
      |                     ^~~~~~~~                                                                                                                           
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:220:21: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by a
dding ‘#include <cstdint>’                                                                                                                                     
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:223:24: error: ‘uint32_t’ has not been declared                                         
  223 |     Tree without_flags(uint32_t clear_flags) const;                                                                                                    
      |                        ^~~~~~~~                                                                                                                        
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:223:24: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by a
dding ‘#include <cstdint>’                                                                                                                                     
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:226:59: error: ‘uint32_t’ has not been declared
  226 |     explicit Tree(const Data* d, bool increment_refcount, uint32_t flags);                                       
      |                                                           ^~~~~~~~                                                                                     
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:226:59: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by a
dding ‘#include <cstdint>’                                                                                                                                     
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp: In copy constructor ‘libfive::Tree::Tree(const libfive::Tree&)’: 
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:51:39: error: ‘const class libfive::Tree’ has no member named ‘flags’                   
   51 |         : Tree(other.ptr, true, other.flags)                                                                                                           
      |                                       ^~~~~                                                                                                            
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp: In constructor ‘libfive::Tree::Tree(libfive::Tree&&)’:
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:54:51: error: class ‘libfive::Tree’ does not have any field named ‘flags’
   54 |         : ptr(std::exchange(other.ptr, nullptr)), flags(other.flags)
      |                                                   ^~~~~
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:54:63: error: ‘class libfive::Tree’ has no member named ‘flags’
   54 |         : ptr(std::exchange(other.ptr, nullptr)), flags(other.flags)
      |                                                               ^~~~~
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp: In member function ‘libfive::Tree& libfive::Tree::operator=(const libfive::Tree&)’:
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:57:52: error: ‘const class libfive::Tree’ has no member named ‘flags’
   57 |         return *this = Tree(other.ptr, true, other.flags);
      |                                                    ^~~~~
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp: In member function ‘libfive::Tree& libfive::Tree::operator=(libfive::Tree&&)’:
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:61:9: error: ‘flags’ was not declared in this scope
   61 |         flags = other.flags;
      |         ^~~~~
/home/gene/Coding/libfive/libfive/src/../include/libfive/tree/tree.hpp:61:23: error: ‘class libfive::Tree’ has no member named ‘flags’
   61 |         flags = other.flags;
```