### PR TITLE
Fix compilation with Eigen 5

### DIFF
--- a/libfive/include/libfive/render/brep/default_new_delete.hpp
+++ b/libfive/include/libfive/render/brep/default_new_delete.hpp
@@ -44,7 +44,7 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 // Eigen 4 makes EIGEN_MAKE_ALIGNED_OPERATOR_NEW a no-op, but... this doesn't
 // seem to work (see libfive issues #462 and #464).  This macro replaces it
 // for new Eigen versions, while staying backwards-compatible for Eigen 3.x
-#if EIGEN_MAJOR_VERSION == 4
+#if EIGEN_MAJOR_VERSION >= 4
 #ifdef _WIN32
 #define ALIGNED_OPERATOR_NEW_AND_DELETE(T) \
     void *operator new[](std::size_t size) {                        \

--- a/libfive/include/libfive/render/brep/per_thread_brep.hpp
+++ b/libfive/include/libfive/render/brep/per_thread_brep.hpp
@@ -9,6 +9,7 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 #pragma once
 
 #include <atomic>
+#include <cassert>
 
 #include <Eigen/Eigen>
 #include <Eigen/StdVector>

--- a/libfive/src/render/discrete/voxels.cpp
+++ b/libfive/src/render/discrete/voxels.cpp
@@ -30,7 +30,7 @@ Voxels::Voxels(const Eigen::Vector3f& _lower, const Eigen::Vector3f& _upper,
     auto extra = (res.array() > 0)
         .select(size.array().cast<float>() / res.array() -
                      (_upper - _lower).array(),
-                Eigen::Array3i::Zero());
+                Eigen::Array3f::Zero());
     lower = _lower.array() - extra/2;
     upper = _upper.array() + extra/2;
 


### PR DESCRIPTION
This PR extends application of the `ALIGNED_OPERATOR_NEW_AND_DELETE` macro to newer Eigen versions (4+) and fixes two other compilation issues (missing include and incorrect argument type)