### PR TITLE
feat: add C and Python bindings for tree serialization and deserialization.

### DIFF
--- a/libfive/bind/python/libfive/ffi.py
+++ b/libfive/bind/python/libfive/ffi.py
@@ -135,6 +135,12 @@ lib.libfive_tree_save_meshes.restype = ctypes.c_uint8
 lib.libfive_tree_save.argtypes = [libfive_tree, ctypes.c_char_p]
 lib.libfive_tree_save.restype = ctypes.c_bool
 
+lib.libfive_tree_serialize.argtypes = [libfive_tree, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t)]
+lib.libfive_tree_serialize.restype = ctypes.c_bool
+
+lib.libfive_tree_deserialize.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+lib.libfive_tree_deserialize.restype = libfive_tree
+
 lib.libfive_tree_load.argtypes = [ctypes.c_char_p]
 lib.libfive_tree_load.restype = libfive_tree
 
@@ -154,3 +160,37 @@ lib.libfive_tree_render_mesh.argtypes = [libfive_tree, libfive_region_t, ctypes.
 lib.libfive_tree_render_mesh.restype = ctypes.POINTER(libfive_mesh_t)
 
 lib.libfive_mesh_delete.argtypes = [ctypes.POINTER(libfive_mesh_t)]
+
+################################################################################
+
+def serialize_tree(tree):
+    """
+    Serializes a tree to a Python bytes object.
+    Automatically handles allocation on the C/C++ side and frees the memory.
+    """
+    buf = ctypes.c_void_p()
+    size = ctypes.c_size_t()
+    
+    success = lib.libfive_tree_serialize(tree, ctypes.byref(buf), ctypes.byref(size))
+    if not success:
+        return None
+        
+    try:
+        if size.value > 0 and buf.value is not None:
+            return ctypes.string_at(buf.value, size.value)
+        return b""
+    finally:
+        if buf.value is not None:
+            lib.libfive_free_str(ctypes.cast(buf, ctypes.c_char_p))
+
+def deserialize_tree(data):
+    """
+    Deserializes a tree from a bytes object.
+    Returns the libfive_tree pointer, or None on failure.
+    """
+    if not isinstance(data, bytes):
+        raise TypeError("Expected bytes object for deserialization")
+    ptr = lib.libfive_tree_deserialize(data, len(data))
+    if ptr is None or ptr == 0:
+        return None
+    return ptr

--- a/libfive/include/libfive.h
+++ b/libfive/include/libfive.h
@@ -284,6 +284,21 @@ void libfive_tree_delete(libfive_tree ptr);
  *  The file format is not archival, and may change without notice */
 bool libfive_tree_save(libfive_tree ptr, const char* filename);
 
+/*
+ *  Serializes the given tree to a memory buffer.
+ *  The buffer contains binary data and is not null-terminated.
+ *  The caller is responsible for freeing the buffer with free().
+ *  Returns true on success, false on failure (e.g., invalid tree, null pointers, or allocation failure).
+ *  On failure, *data is set to nullptr and *size is set to 0.
+ */
+bool libfive_tree_serialize(libfive_tree ptr, char** data, size_t* size);
+
+/*
+ *  Deserializes a tree from a memory buffer.
+ *  Returns the deserialized tree, or NULL on failure.
+ */
+libfive_tree libfive_tree_deserialize(const char* data, size_t size);
+
 /*  Deserializes a tree from a file. */
 libfive_tree libfive_tree_load(const char* filename);
 

--- a/libfive/src/libfive.cpp
+++ b/libfive/src/libfive.cpp
@@ -8,6 +8,7 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 #include "libfive.h"
 
@@ -166,6 +167,65 @@ bool libfive_tree_save(libfive_tree ptr, const char* filename)
     {
         std::cerr << "libfive_tree_save: could not open file" << std::endl;
         return false;
+    }
+}
+
+bool libfive_tree_serialize(libfive_tree ptr, char** data, size_t* size)
+{
+    if (data == nullptr || size == nullptr)
+    {
+        return false;
+    }
+    *data = nullptr;
+    *size = 0;
+    if (ptr == nullptr)
+    {
+        return false;
+    }
+
+    try {
+        std::stringstream ss;
+        Tree(ptr).serialize(ss);
+        std::string s = ss.str();
+        if (s.empty()) {
+            return true;
+        }
+
+        char* buf = (char*)malloc(s.length());
+        if (buf == nullptr) {
+            return false;
+        }
+
+        memcpy(buf, s.data(), s.length());
+        *data = buf;
+        *size = s.length();
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+libfive_tree libfive_tree_deserialize(const char* data, size_t size)
+{
+    if (data == nullptr || size == 0)
+    {
+        return nullptr;
+    }
+
+    try {
+        std::string s(data, size);
+        std::stringstream ss(s);
+        auto t = Tree::deserialize(ss);
+        if (t.id() && t.is_valid())
+        {
+            return t.release();
+        }
+        else
+        {
+            return nullptr;
+        }
+    } catch (...) {
+        return nullptr;
     }
 }
 


### PR DESCRIPTION
**Description:**

This PR adds memory buffer-based serialization and deserialization capabilities for libfive trees, complementing the existing file-based save/load functionality.

### Changes

#### Core C Library (`libfive/src/libfive.cpp`)
- **`libfive_tree_serialize()`**: Serializes a tree to a binary memory buffer. The function:
  - Allocates memory for the serialized data on the C/C++ side
  - Returns a pointer to the buffer and its size via output parameters
  - Caller is responsible for freeing the buffer with `free()`
  - Returns `true` on success, `false` on failure (invalid tree, null pointers, or allocation failure)
  - Includes comprehensive error handling with try-catch

- **`libfive_tree_deserialize()`**: Deserializes a tree from a binary memory buffer:
  - Takes a buffer pointer and size as input
  - Returns the reconstructed `libfive_tree` pointer
  - Returns `NULL` on failure with robust error handling

#### Header File (`libfive/include/libfive.h`)
- Added function declarations with detailed documentation
- Specifies the contract: binary non-null-terminated format, caller memory management responsibilities

#### Python Bindings (`libfive/bind/python/libfive/ffi.py`)
- **`serialize_tree(tree)`**: High-level wrapper that:
  - Automatically handles C/C++ side memory allocation
  - Returns a Python `bytes` object
  - Automatically frees C-side memory using `libfive_free_str()`
  - Returns `None` on failure

- **`deserialize_tree(data)`**: High-level wrapper that:
  - Accepts Python `bytes` objects
  - Validates input type
  - Returns the deserialized tree pointer or `None` on failure

### Benefits
- Enables efficient tree serialization without disk I/O
- Useful for in-memory data transfer, network communication, and caching
- Clean Python API that handles memory management automatically
- Memory-safe with proper error handling and exception catching